### PR TITLE
Feature/nav control #85

### DIFF
--- a/server/test-malcolm-server.js
+++ b/server/test-malcolm-server.js
@@ -12,11 +12,22 @@ const io = new WebSocket.Server({port: 8000});
 
 io.on('connection', function (socket) {
   socket.on('message', message => {
-    message = JSON.parse(message);
-    handleMessage(socket, message);
+    try {
+      message = JSON.parse(message);
+      handleMessage(socket, message);
+    } catch (error) {
+      console.log(error);
+    }
   });
   socket.on('disconnect', () => handleDisconnect());
+  socket.on('error', (err) => {
+    subscriptionFeed.cancelAllSubscriptions();
+    console.log('errored');
+    console.log(err);
+  });
 });
+
+
 
 const port = 8000;
 console.log('listening on port ', port);
@@ -45,7 +56,9 @@ function handleMessage(socket, message) {
 
 function sendResponse(socket, message) {
   setTimeout(() => {
-    socket.send(JSON.stringify(message))
+    if (socket.readyState === socket.OPEN) {
+      socket.send(JSON.stringify(message))
+    }
   }, Math.ceil(settings.delay*Math.random()));
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -31,3 +31,7 @@
     transform: rotate(360deg);
   }
 }
+
+option {
+  color: black;
+}

--- a/src/drawerContainer/__snapshots__/drawerContainer.test.js.snap
+++ b/src/drawerContainer/__snapshots__/drawerContainer.test.js.snap
@@ -23,6 +23,7 @@ exports[`DrawerContainer renders correctly 1`] = `
     >
       <DrawerHeader
         closeAction={[Function]}
+        popOutAction={[Function]}
         title="Parent"
       />
       <div>
@@ -45,6 +46,7 @@ exports[`DrawerContainer renders correctly 1`] = `
     >
       <DrawerHeader
         closeAction={[Function]}
+        popOutAction={[Function]}
         title="Child"
       />
       <div>

--- a/src/drawerContainer/drawerContainer.test.js
+++ b/src/drawerContainer/drawerContainer.test.js
@@ -25,6 +25,7 @@ describe('DrawerContainer', () => {
         openChildPanel: true,
       },
       malcolm: {
+        blocks: {},
         navigation: ['PANDA'],
       },
     };

--- a/src/drawerContainer/drawerContainer.test.js
+++ b/src/drawerContainer/drawerContainer.test.js
@@ -41,6 +41,7 @@ describe('DrawerContainer', () => {
         store={mockStore(state)}
         parentTitle="Parent"
         childTitle="Child"
+        popOutAction={() => {}}
       >
         <div>Left</div>
         <div>Middle</div>
@@ -55,7 +56,11 @@ describe('DrawerContainer', () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <DrawerContainer parentTitle="Parent" childTitle="Child">
+        <DrawerContainer
+          parentTitle="Parent"
+          childTitle="Child"
+          popOutAction={() => {}}
+        >
           <div>Left</div>
           <div>Middle</div>
           <div>Right</div>
@@ -81,7 +86,11 @@ describe('DrawerContainer', () => {
 
     const wrapper = mount(
       <Provider store={store}>
-        <DrawerContainer parentTitle="Parent" childTitle="Child">
+        <DrawerContainer
+          parentTitle="Parent"
+          childTitle="Child"
+          popOutAction={() => {}}
+        >
           <div>Left</div>
           <div>Middle</div>
           <div>Right</div>

--- a/src/malcolm/malcolm.types.js
+++ b/src/malcolm/malcolm.types.js
@@ -2,6 +2,7 @@ export const MalcolmSend = 'malcolm:send';
 export const MalcolmError = 'malcolm:error';
 export const MalcolmNewBlock = 'malcolm:newblock';
 export const MalcolmBlockMeta = 'malcolm:blockmeta';
+export const MalcolmRootBlockMeta = 'malcolm:rootblock';
 export const MalcolmAttributeData = 'malcolm:attributedata';
 export const MalcolmAttributePending = 'malcolm:attributepending';
 export const MalcolmSnackbar = 'malcolm:snackbar';

--- a/src/malcolm/malcolmHandlers/attributeHandler.js
+++ b/src/malcolm/malcolmHandlers/attributeHandler.js
@@ -27,6 +27,35 @@ const processScalarAttribute = (request, changes, dispatch) => {
   dispatch(action);
 };
 
+const processTableAttribute = (request, changes, dispatch) => {
+  const inGroup = changes.meta.tags.some(t => t.indexOf('group:') > -1);
+  const group = inGroup
+    ? changes.meta.tags
+        .find(t => t.indexOf('group:') > -1)
+        .replace('group:', '')
+    : '';
+
+  const action = {
+    type: MalcolmAttributeData,
+    payload: {
+      id: request.id,
+      typeid: changes.typeid,
+      isGroup: changes.meta.tags.some(t => t === 'widget:group'),
+      inGroup,
+      group,
+      meta: changes.meta,
+      alarm: changes.alarm,
+      labels: changes.labels,
+      value: changes.value,
+      delta: true,
+      pending: false,
+    },
+  };
+
+  dispatch(action);
+};
+
 export default {
   processScalarAttribute,
+  processTableAttribute,
 };

--- a/src/malcolm/malcolmHandlers/attributeHandler.test.js
+++ b/src/malcolm/malcolmHandlers/attributeHandler.test.js
@@ -61,4 +61,16 @@ describe('attribute handler', () => {
     expect(dispatches[0].payload.inGroup).toEqual(false);
     expect(dispatches[0].payload.isGroup).toEqual(false);
   });
+
+  it('processes and dispatches a table attribute update', () => {
+    const tableChanges = changes(['group:outputs']);
+    tableChanges.typeid = 'NTTable';
+    AttributeHandler.processTableAttribute(request, tableChanges, dispatch);
+
+    expect(dispatches.length).toEqual(1);
+    expect(dispatches[0].type).toEqual(MalcolmAttributeData);
+    expect(dispatches[0].payload.id).toEqual(1);
+    expect(dispatches[0].payload.typeid).toEqual('NTTable');
+    expect(dispatches[0].payload.delta).toEqual(true);
+  });
 });

--- a/src/malcolm/malcolmHandlers/blockMetaHandler.js
+++ b/src/malcolm/malcolmHandlers/blockMetaHandler.js
@@ -1,7 +1,7 @@
-import { MalcolmBlockMeta } from '../malcolm.types';
+import { MalcolmBlockMeta, MalcolmRootBlockMeta } from '../malcolm.types';
 import { malcolmSubscribeAction } from '../malcolmActionCreators';
 
-const BlockMetaHandler = (request, changes, dispatch) => {
+export const BlockMetaHandler = (request, changes, dispatch) => {
   const action = {
     type: MalcolmBlockMeta,
     payload: {
@@ -20,6 +20,18 @@ const BlockMetaHandler = (request, changes, dispatch) => {
       dispatch(malcolmSubscribeAction([...request.path.slice(0, -1), field]));
     });
   }
+};
+
+export const RootBlockHandler = (request, blocks, dispatch) => {
+  const action = {
+    type: MalcolmRootBlockMeta,
+    payload: {
+      id: request.id,
+      blocks,
+    },
+  };
+
+  dispatch(action);
 };
 
 export default BlockMetaHandler;

--- a/src/malcolm/malcolmHandlers/blockMetaHandler.test.js
+++ b/src/malcolm/malcolmHandlers/blockMetaHandler.test.js
@@ -1,4 +1,4 @@
-import BlockMetaHandler from './blockMetaHandler';
+import { BlockMetaHandler } from './blockMetaHandler';
 import { MalcolmBlockMeta, MalcolmSend } from '../malcolm.types';
 
 describe('block meta handler', () => {

--- a/src/malcolm/malcolmSocketHandler.js
+++ b/src/malcolm/malcolmSocketHandler.js
@@ -1,4 +1,7 @@
-import BlockMetaHandler from './malcolmHandlers/blockMetaHandler';
+import {
+  BlockMetaHandler,
+  RootBlockHandler,
+} from './malcolmHandlers/blockMetaHandler';
 import AttributeHandler from './malcolmHandlers/attributeHandler';
 import { malcolmSnackbarState } from './malcolmActionCreators';
 import { MalcolmAttributeData } from './malcolm.types';
@@ -29,6 +32,17 @@ const configureMalcolmSocketHandlers = (inputSocketContainer, store) => {
   socketContainer.socket.onmessage = event => {
     const data = JSON.parse(event.data);
     switch (data.typeid) {
+      case 'malcolm:core/Update:1.0': {
+        const originalRequest = store
+          .getState()
+          .malcolm.messagesInFlight.find(m => m.id === data.id);
+
+        if (originalRequest.path.join('') === '.blocks') {
+          RootBlockHandler(originalRequest, data.value, store.dispatch);
+        }
+
+        break;
+      }
       case 'malcolm:core/Delta:1.0': {
         const { changes } = data;
         const originalRequest = store
@@ -97,6 +111,14 @@ const configureMalcolmSocketHandlers = (inputSocketContainer, store) => {
 
           case 'epics:nt/NTScalar:1.0':
             AttributeHandler.processScalarAttribute(
+              originalRequest,
+              attribute,
+              store.dispatch
+            );
+            break;
+
+          case 'epics:nt/NTTable:1.0':
+            AttributeHandler.processTableAttribute(
               originalRequest,
               attribute,
               store.dispatch

--- a/src/malcolm/malcolmSocketHandler.test.js
+++ b/src/malcolm/malcolmSocketHandler.test.js
@@ -3,6 +3,7 @@ import {
   MalcolmBlockMeta,
   MalcolmAttributeData,
   MalcolmSnackbar,
+  MalcolmRootBlockMeta,
 } from './malcolm.types';
 
 describe('malcolm socket handler', () => {
@@ -25,6 +26,10 @@ describe('malcolm socket handler', () => {
           id: 3,
           path: ['TestBlock', 'TestAttr'],
           value: null,
+        },
+        {
+          id: 4,
+          path: ['.', 'blocks'],
         },
       ],
       blocks: {
@@ -110,7 +115,7 @@ describe('malcolm socket handler', () => {
     expect(dispatches[0].payload.label).toEqual('Block 1');
   });
 
-  it('handles attribute updates', () => {
+  it('handles scalar attribute updates', () => {
     const changes = {
       label: 'Attribute 1',
       meta: {
@@ -124,6 +129,22 @@ describe('malcolm socket handler', () => {
     expect(dispatches.length).toEqual(1);
     expect(dispatches[0].type).toEqual(MalcolmAttributeData);
     expect(dispatches[0].payload.typeid).toEqual('epics:nt/NTScalar:1.0');
+  });
+
+  it('handles table attribute updates', () => {
+    const changes = {
+      label: 'Attribute 1',
+      meta: {
+        tags: [],
+      },
+    };
+    const message = buildMessage('epics:nt/NTTable:1.0', 2, changes);
+
+    socketContainer.socket.send(message);
+
+    expect(dispatches.length).toEqual(1);
+    expect(dispatches[0].type).toEqual(MalcolmAttributeData);
+    expect(dispatches[0].payload.typeid).toEqual('epics:nt/NTTable:1.0');
   });
 
   it('dispatches a message for unhandled deltas', () => {
@@ -201,6 +222,24 @@ describe('malcolm socket handler', () => {
     expect(
       store.getState().malcolm.blocks.TestBlock.attributes[0].pending
     ).toEqual(false);
+  });
+
+  it('only processes an update for the root .blocks item', () => {
+    const message = JSON.stringify({
+      typeid: 'malcolm:core/Update:1.0',
+      id: 4,
+      value: ['block1', 'block2', 'block3'],
+    });
+
+    socketContainer.socket.send(message);
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0].type).toEqual(MalcolmRootBlockMeta);
+    expect(dispatches[0].payload.blocks).toEqual([
+      'block1',
+      'block2',
+      'block3',
+    ]);
   });
   // TODO: add tests for DELTA handling
 });

--- a/src/malcolm/middleware/malcolmReduxMiddleware.test.js
+++ b/src/malcolm/middleware/malcolmReduxMiddleware.test.js
@@ -106,7 +106,7 @@ describe('malcolm reducer', () => {
 
     middleware(store)(next)(action);
 
-    expect(dispatches.length).toEqual(5);
+    expect(dispatches.length).toEqual(7);
 
     expect(dispatches[0].type).toEqual(MalcolmNavigationPathUpdate);
     expect(dispatches[0].payload.blockPaths).toEqual([
@@ -116,17 +116,24 @@ describe('malcolm reducer', () => {
     ]);
 
     expect(dispatches[1].type).toEqual(MalcolmNewBlock);
-    expect(dispatches[1].payload.blockName).toEqual('PANDA');
+    expect(dispatches[1].payload.blockName).toEqual('.blocks');
 
     expect(dispatches[2].type).toEqual(MalcolmSend);
     expect(dispatches[2].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
-    expect(dispatches[2].payload.path).toEqual(['PANDA', 'meta']);
+    expect(dispatches[2].payload.path).toEqual(['.', 'blocks']);
 
     expect(dispatches[3].type).toEqual(MalcolmNewBlock);
-    expect(dispatches[3].payload.blockName).toEqual('PANDA:TTLIN1');
+    expect(dispatches[3].payload.blockName).toEqual('PANDA');
 
     expect(dispatches[4].type).toEqual(MalcolmSend);
     expect(dispatches[4].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
-    expect(dispatches[4].payload.path).toEqual(['PANDA:TTLIN1', 'meta']);
+    expect(dispatches[4].payload.path).toEqual(['PANDA', 'meta']);
+
+    expect(dispatches[5].type).toEqual(MalcolmNewBlock);
+    expect(dispatches[5].payload.blockName).toEqual('PANDA:TTLIN1');
+
+    expect(dispatches[6].type).toEqual(MalcolmSend);
+    expect(dispatches[6].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
+    expect(dispatches[6].payload.path).toEqual(['PANDA:TTLIN1', 'meta']);
   });
 });

--- a/src/malcolm/middleware/malcolmRouting.js
+++ b/src/malcolm/middleware/malcolmRouting.js
@@ -6,8 +6,15 @@ import {
 
 const handleLocationChange = (path, dispatch) => {
   // remove the first part of the url e.g. /gui/ or /details/
-  const tokens = path.split('/').slice(2);
+  const tokens = path
+    .replace(/\/$/, '')
+    .split('/')
+    .slice(2);
   dispatch(malcolmNavigationPath(tokens));
+
+  // Get the root list of blocks
+  dispatch(malcolmNewBlockAction('.blocks', false, false));
+  dispatch(malcolmSubscribeAction(['.', 'blocks']));
 
   // TODO: handle layout routing
 

--- a/src/malcolm/middleware/malcolmRouting.js
+++ b/src/malcolm/middleware/malcolmRouting.js
@@ -7,7 +7,7 @@ import {
 const handleLocationChange = (path, dispatch) => {
   // remove the first part of the url e.g. /gui/ or /details/
   const tokens = path
-    .replace(/\/$/, '')
+    .replace(/\/$/, '') // strip off the trailing /
     .split('/')
     .slice(2);
   dispatch(malcolmNavigationPath(tokens));

--- a/src/malcolm/reducer/attribute.reducer.js
+++ b/src/malcolm/reducer/attribute.reducer.js
@@ -1,0 +1,53 @@
+function updateAttributeChildren(attribute) {
+  const updatedAttribute = { ...attribute };
+  if (updatedAttribute.meta) {
+    // Find children for the layout attribute
+    if (updatedAttribute.meta.elements && updatedAttribute.meta.elements.mri) {
+      updatedAttribute.children = updatedAttribute.value.mri;
+    }
+  }
+
+  return updatedAttribute;
+}
+
+function updateAttribute(state, payload) {
+  if (payload.delta) {
+    const { path } = state.messagesInFlight.find(m => m.id === payload.id);
+    const blockName = path[0];
+    const attributeName = path[1];
+
+    if (Object.prototype.hasOwnProperty.call(state.blocks, blockName)) {
+      const attributes = [...state.blocks[blockName].attributes];
+
+      const matchingAttribute = attributes.findIndex(
+        a => a.name === attributeName
+      );
+      if (matchingAttribute >= 0) {
+        attributes[matchingAttribute] = {
+          ...attributes[matchingAttribute],
+          loading: false,
+          path,
+          pending: false,
+          ...payload,
+        };
+
+        attributes[matchingAttribute] = updateAttributeChildren(
+          attributes[matchingAttribute]
+        );
+      }
+      const blocks = { ...state.blocks };
+      blocks[blockName] = { ...state.blocks[blockName], attributes };
+
+      return {
+        ...state,
+        blocks,
+      };
+    }
+  }
+
+  return state;
+}
+
+export default {
+  updateAttribute,
+};

--- a/src/malcolm/reducer/attribute.reducer.test.js
+++ b/src/malcolm/reducer/attribute.reducer.test.js
@@ -1,0 +1,56 @@
+import AttributeReducer from './attribute.reducer';
+
+describe('attribute reducer', () => {
+  it('updates children for layout attribute', () => {
+    let state = {
+      messagesInFlight: [
+        {
+          id: 1,
+          path: ['block1', 'layout'],
+        },
+      ],
+      blocks: {
+        block1: {
+          attributes: [
+            {
+              name: 'layout',
+              children: [],
+            },
+          ],
+        },
+      },
+    };
+
+    const payload = {
+      delta: true,
+      id: 1,
+      meta: {
+        elements: {
+          mri: {},
+        },
+      },
+      value: {
+        mri: ['block2', 'block3', 'block4'],
+      },
+    };
+
+    state = AttributeReducer.updateAttribute(state, payload);
+
+    expect(state.blocks.block1.attributes[0].children).toHaveLength(3);
+    expect(state.blocks.block1.attributes[0].children).toEqual([
+      'block2',
+      'block3',
+      'block4',
+    ]);
+  });
+
+  it('returns state if it is not a delta', () => {
+    const state = {
+      property: 'test',
+    };
+
+    const updatedState = AttributeReducer.updateAttribute(state, {});
+
+    expect(updatedState).toBe(state);
+  });
+});

--- a/src/malcolm/reducer/malcolmReducer.test.js
+++ b/src/malcolm/reducer/malcolmReducer.test.js
@@ -98,8 +98,8 @@ describe('malcolm reducer', () => {
     expect(state.blocks.block1.loading).toEqual(false);
     expect(state.blocks.block1.label).toEqual('Block 1');
     expect(state.blocks.block1.attributes).toEqual([
-      { name: 'health', loading: true },
-      { name: 'icon', loading: true },
+      { name: 'health', loading: true, children: [] },
+      { name: 'icon', loading: true, children: [] },
     ]);
   });
 

--- a/src/malcolm/reducer/malcolmReducer.test.js
+++ b/src/malcolm/reducer/malcolmReducer.test.js
@@ -8,6 +8,7 @@ import {
   MalcolmAttributeData,
   MalcolmAttributePending,
   MalcolmSnackbar,
+  MalcolmRootBlockMeta,
 } from '../malcolm.types';
 import NavigationReducer from './navigation.reducer';
 
@@ -194,5 +195,24 @@ describe('malcolm reducer', () => {
 
     expect(state.snackbar.open).toEqual(true);
     expect(state.snackbar.message).toEqual('This is a test!');
+  });
+
+  it('updates the root block', () => {
+    const blocks = ['block1', 'block2'];
+    const action = {
+      type: MalcolmRootBlockMeta,
+      payload: {
+        id: 1,
+        blocks,
+      },
+    };
+
+    state.blocks['.blocks'] = {
+      children: [],
+    };
+
+    state = malcolmReducer(state, action);
+
+    expect(state.blocks['.blocks'].children).toEqual(blocks);
   });
 });

--- a/src/malcolm/reducer/navigation.reducer.js
+++ b/src/malcolm/reducer/navigation.reducer.js
@@ -1,6 +1,5 @@
 function updateNavigationPath(state, payload) {
   const navigation = payload.blockPaths;
-
   return { ...state, navigation };
 }
 

--- a/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
@@ -82,6 +82,7 @@ AttributeSelector.propTypes = {
       PropTypes.bool,
       PropTypes.number,
       PropTypes.string,
+      PropTypes.shape({}),
     ]),
     pending: PropTypes.bool,
   }).isRequired,

--- a/src/navbar/__snapshots__/navbar.test.js.snap
+++ b/src/navbar/__snapshots__/navbar.test.js.snap
@@ -16,24 +16,33 @@ exports[`NavBar renders correctly 1`] = `
     <div
       className="Connect-NavBar--title-7 Connect-NavBar--titleShift-8"
     >
-      <WithStyles(Typography)
-        className="Connect-NavBar--navPath-9"
+      <WithStyles(NavControl)
         key="PANDA"
-      >
-        PANDA
-      </WithStyles(Typography)>
-      <WithStyles(Typography)
-        className="Connect-NavBar--navPath-9"
+        nav={
+          Object {
+            "children": Array [],
+            "path": "PANDA",
+          }
+        }
+      />
+      <WithStyles(NavControl)
         key="layout"
-      >
-        layout
-      </WithStyles(Typography)>
-      <WithStyles(Typography)
-        className="Connect-NavBar--navPath-9"
+        nav={
+          Object {
+            "children": Array [],
+            "path": "layout",
+          }
+        }
+      />
+      <WithStyles(NavControl)
         key="PANDA:SEQ1"
-      >
-        PANDA:SEQ1
-      </WithStyles(Typography)>
+        nav={
+          Object {
+            "children": Array [],
+            "path": "PANDA:SEQ1",
+          }
+        }
+      />
     </div>
   </WithStyles(Toolbar)>
 </WithStyles(AppBar)>

--- a/src/navbar/__snapshots__/navcontrol.test.js.snap
+++ b/src/navbar/__snapshots__/navcontrol.test.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavControl disables menu item if children is empty 1`] = `
+<div
+  className="NavControl-container-1"
+>
+  <WithStyles(IconButton)
+    disabled={true}
+    onClick={[Function]}
+  >
+    <pure(KeyboardArrowDown) />
+  </WithStyles(IconButton)>
+  <WithStyles(Typography)>
+    PANDA
+  </WithStyles(Typography)>
+  <WithStyles(Menu)
+    anchorEl={null}
+    id="simple-menu"
+    onClose={[Function]}
+    open={false}
+  />
+</div>
+`;
+
+exports[`NavControl renders correctly 1`] = `
+<div
+  className="NavControl-container-1"
+>
+  <WithStyles(IconButton)
+    disabled={false}
+    onClick={[Function]}
+  >
+    <pure(KeyboardArrowDown) />
+  </WithStyles(IconButton)>
+  <WithStyles(Typography)>
+    PANDA
+  </WithStyles(Typography)>
+  <WithStyles(Menu)
+    anchorEl={null}
+    id="simple-menu"
+    onClose={[Function]}
+    open={false}
+  >
+    <WithStyles(MenuItem)
+      key="layout"
+      onClick={[Function]}
+    >
+      layout
+    </WithStyles(MenuItem)>
+    <WithStyles(MenuItem)
+      key="table"
+      onClick={[Function]}
+    >
+      table
+    </WithStyles(MenuItem)>
+  </WithStyles(Menu)>
+</div>
+`;

--- a/src/navbar/navbar.component.js
+++ b/src/navbar/navbar.component.js
@@ -10,46 +10,9 @@ import Typography from 'material-ui/Typography';
 import MenuIcon from '@material-ui/icons/Menu';
 import { openParentPanel } from '../viewState/viewState.actions';
 import NavControl from './navcontrol.component';
+import NavBarSelector from './navbar.selector';
 
 const drawerWidth = 320;
-
-const processNavigationLists = (paths, blocks) => {
-  const navigationLists = paths.map(p => ({
-    path: p,
-    children: [],
-  }));
-
-  if (navigationLists.length === 0) {
-    navigationLists.push({
-      path: '',
-      children: [],
-    });
-  }
-
-  if (Object.prototype.hasOwnProperty.call(blocks, '.blocks')) {
-    navigationLists[0].children = blocks['.blocks'].children;
-  }
-
-  let previousBlock;
-  for (let i = 1; i < paths.length; i += 1) {
-    const path = paths[i - 1];
-
-    if (Object.prototype.hasOwnProperty.call(blocks, path)) {
-      previousBlock = blocks[path];
-      navigationLists[i].children = previousBlock.children;
-    } else if (previousBlock && previousBlock.attributes) {
-      const matchingAttribute = previousBlock.attributes.findIndex(
-        a => a.name === path
-      );
-      if (matchingAttribute > -1) {
-        const attribute = previousBlock.attributes[matchingAttribute];
-        navigationLists[i].children = attribute.children;
-      }
-    }
-  }
-
-  return navigationLists;
-};
 
 const styles = theme => ({
   appBar: {
@@ -136,7 +99,7 @@ const NavBar = props => (
 
 const mapStateToProps = state => ({
   open: state.viewState.openParentPanel,
-  navigation: processNavigationLists(
+  navigation: NavBarSelector.processNavigationLists(
     state.malcolm.navigation,
     state.malcolm.blocks
   ),

--- a/src/navbar/navbar.selector.js
+++ b/src/navbar/navbar.selector.js
@@ -1,0 +1,41 @@
+const processNavigationLists = (paths, blocks) => {
+  const navigationLists = paths.map(p => ({
+    path: p,
+    children: [],
+  }));
+
+  if (navigationLists.length === 0) {
+    navigationLists.push({
+      path: '',
+      children: [],
+    });
+  }
+
+  if (Object.prototype.hasOwnProperty.call(blocks, '.blocks')) {
+    navigationLists[0].children = blocks['.blocks'].children;
+  }
+
+  let previousBlock;
+  for (let i = 1; i < paths.length; i += 1) {
+    const path = paths[i - 1];
+
+    if (Object.prototype.hasOwnProperty.call(blocks, path)) {
+      previousBlock = blocks[path];
+      navigationLists[i].children = previousBlock.children;
+    } else if (previousBlock && previousBlock.attributes) {
+      const matchingAttribute = previousBlock.attributes.findIndex(
+        a => a.name === path
+      );
+      if (matchingAttribute > -1) {
+        const attribute = previousBlock.attributes[matchingAttribute];
+        navigationLists[i].children = attribute.children;
+      }
+    }
+  }
+
+  return navigationLists;
+};
+
+export default {
+  processNavigationLists,
+};

--- a/src/navbar/navbar.selector.test.js
+++ b/src/navbar/navbar.selector.test.js
@@ -1,0 +1,60 @@
+import NavBarSelector from './navbar.selector';
+
+describe('NavBarSelector', () => {
+  let blocks;
+
+  beforeEach(() => {
+    blocks = {
+      '.blocks': {
+        children: ['block1', 'block2'],
+      },
+      block1: {
+        attributes: [
+          {
+            name: 'layout',
+            children: ['block5', 'block6'],
+          },
+        ],
+        children: ['block2'],
+      },
+      block2: {
+        children: ['block3', 'block4'],
+      },
+    };
+  });
+
+  it('returns the .block blocks if the paths are empty', () => {
+    const navLists = NavBarSelector.processNavigationLists([], blocks);
+
+    expect(navLists).toHaveLength(1);
+    expect(navLists[0].path).toBe('');
+    expect(navLists[0].children).toBe(blocks['.blocks'].children);
+  });
+
+  it('populates nav lists from blocks if present', () => {
+    const paths = ['block1', 'block2'];
+    const navLists = NavBarSelector.processNavigationLists(paths, blocks);
+
+    expect(navLists).toHaveLength(2);
+    expect(navLists[0].path).toBe('block1');
+    expect(navLists[0].children).toBe(blocks['.blocks'].children);
+
+    expect(navLists[1].path).toBe('block2');
+    expect(navLists[1].children).toBe(blocks.block1.children);
+  });
+
+  it('populates nav lists from attributes of the previous block if no block is found', () => {
+    const paths = ['block1', 'layout', 'block3'];
+    const navLists = NavBarSelector.processNavigationLists(paths, blocks);
+
+    expect(navLists).toHaveLength(3);
+    expect(navLists[0].path).toBe('block1');
+    expect(navLists[0].children).toBe(blocks['.blocks'].children);
+
+    expect(navLists[1].path).toBe('layout');
+    expect(navLists[1].children).toBe(blocks.block1.children);
+
+    expect(navLists[2].path).toBe('block3');
+    expect(navLists[2].children).toEqual(['block5', 'block6']);
+  });
+});

--- a/src/navbar/navbar.test.js
+++ b/src/navbar/navbar.test.js
@@ -22,6 +22,7 @@ describe('NavBar', () => {
         openChildPanel: true,
       },
       malcolm: {
+        blocks: {},
         navigation: ['PANDA', 'layout', 'PANDA:SEQ1'],
       },
     };
@@ -44,7 +45,10 @@ describe('NavBar', () => {
 
     const wrapper = mount(<NavBar store={store} />);
 
-    wrapper.find('button').simulate('click');
+    wrapper
+      .find('button')
+      .at(0)
+      .simulate('click');
 
     const actions = store.getActions();
     expect(actions.length).toEqual(1);

--- a/src/navbar/navcontrol.component.js
+++ b/src/navbar/navcontrol.component.js
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import Typography from 'material-ui/Typography';
+import IconButton from 'material-ui/IconButton';
+import { KeyboardArrowDown } from '@material-ui/icons';
+import Menu, { MenuItem } from 'material-ui/Menu';
+
+const styles = {
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+};
+
+class NavControl extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      anchorEl: null,
+    };
+
+    this.handleClick = this.handleClick.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  handleClick(event) {
+    this.setState({ anchorEl: event.currentTarget });
+  }
+
+  handleClose() {
+    this.setState({ anchorEl: null });
+  }
+
+  render() {
+    const { classes, nav } = this.props;
+    const { anchorEl } = this.state;
+
+    return (
+      <div className={classes.container}>
+        <IconButton
+          onClick={this.handleClick}
+          disabled={nav.children.length === 0}
+        >
+          <KeyboardArrowDown />
+        </IconButton>
+        <Typography>{nav.path}</Typography>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={this.handleClose}
+        >
+          {nav.children.map(child => (
+            <MenuItem key={child} onClick={this.handleClose}>
+              {child}
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    );
+  }
+}
+
+NavControl.propTypes = {
+  nav: PropTypes.shape({
+    path: PropTypes.string,
+    children: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
+  classes: PropTypes.shape({
+    container: PropTypes.string,
+  }).isRequired,
+};
+
+export default withStyles(styles, { withTheme: true })(NavControl);

--- a/src/navbar/navcontrol.test.js
+++ b/src/navbar/navcontrol.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { createShallow } from 'material-ui/test-utils';
+import NavControl from './navcontrol.component';
+
+describe('NavControl', () => {
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow({ dive: true });
+  });
+
+  it('renders correctly', () => {
+    const nav = {
+      path: 'PANDA',
+      children: ['layout', 'table'],
+    };
+
+    const wrapper = shallow(<NavControl nav={nav} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('disables menu item if children is empty', () => {
+    const nav = {
+      path: 'PANDA',
+      children: [],
+    };
+
+    const wrapper = shallow(<NavControl nav={nav} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Description

- Hooked up the contents of the drop downs to blocks at the parent level.
- Made the socket connection on the test server more robust.
- Added very basic table attribute handling to get blocks from the layout attribute.
- Updated the route handing so it subscribes to blocks in the route.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Run `npm start` and navigate to http://localhost:3000/gui/PANDA/layout/PANDA:SEQ1

## Agile board tracking

connect to #85 
connect to #86 

