### PR TITLE
Feature/theming docs #74

### DIFF
--- a/docs/source/SMG/MUI_theming.rst
+++ b/docs/source/SMG/MUI_theming.rst
@@ -1,0 +1,28 @@
+Material-UI Theming
+===================
+
+A useful feature of Material-UI is the provision of theme objects; these allow various styling parameters to be defined
+at a top level and passed down to components which need them.
+
+At its core, a theme is defined as being either light or dark. It then defines colours in a palette object;
+this palette contains a set of primary, secondary and error colours, each of these having a light, main, dark and
+contrast text colour. It is possible to let these colour be entirely auto-generated (specifying whether
+the theme is to be light or dark), entirely manually defined or partially auto-generated (any of the sub-palettes will
+be auto-generated if not defined, and specifying a main colour for each will allow the other colours in the sub-palette
+to be auto-generated from this).
+
+It is also possible to specify custom parameters as part of the theme by passing them to createMuiTheme
+(in the same object and at the same level as palette).
+
+.. code-block:: javascript
+
+    const theme = createMuiTheme({
+        palette: {
+            type: 'dark',
+        },
+        alarmState: {
+            warning: '#e6c01c',
+        },
+    });
+
+More information can be found `here <https://material-ui.com/customization/themes/>`_.

--- a/docs/source/SMG/MUI_theming.rst
+++ b/docs/source/SMG/MUI_theming.rst
@@ -1,5 +1,8 @@
+Styling
+=======
+
 Material-UI Theming
-===================
+###################
 
 A useful feature of Material-UI is the provision of theme objects; these allow various styling parameters to be defined
 at a top level and passed down to components which need them.

--- a/docs/source/SMG/architecture.rst
+++ b/docs/source/SMG/architecture.rst
@@ -6,7 +6,7 @@ Context
 
 `Malcolm <http://pymalcolm.readthedocs.io/en/latest/>`_ provides a higher level abstraction over EPICS for monitoring and controlling devices (e.g. motor controllers or area detectors). **MalcolmJS** is a user interface for Malcolm that allows blocks to be wired together and more complex behaviours to be programmed into the hardware (e.g. custom scan patterns).
 
-.. figure:: architecture_diagrams/malcolmjs_context.png
+.. figure:: architecture_diagrams/malcolmjs_context.draw-io.png
     :align: center
 
     MalcolmJS context within its wider environment
@@ -22,7 +22,7 @@ Containers
 
 The container view for MalcolmJS breaks down in to the main user interface categories as well as the interface for interacting with Malcolm.
 
-.. figure:: architecture_diagrams/malcolmjs_containers.png
+.. figure:: architecture_diagrams/malcolmjs_containers.draw-io.png
     :align: center
 
     MalcolmJS container view
@@ -49,7 +49,7 @@ Malcolm works on a subscribe/unsubscribe model - in order to clean up connection
 
 One of the best ways to think about the high level structure for MalcolmJS is to consider the high level user interface mock ups. They show the main sections of the interface and thus how the application breaks down into containers.
 
-.. figure:: architecture_diagrams/malcolmjs_desktop_mockup.png
+.. figure:: architecture_diagrams/malcolmjs_desktop_mockup.draw-io.png
     :align: center
 
     MalcolmJS desktop view
@@ -68,7 +68,7 @@ Once they click on a block in the central panel then it will display information
 On a multi-monitor system it can be useful to keep track of block details for various blocks in the tree, this is why there is a pop-out button. The user can choose to show the attributes for a particular block in a standalone window. It it worth noting that this is also what the mobile view would display.
 
 
-.. figure:: architecture_diagrams/malcolmjs_phone_mockup.png
+.. figure:: architecture_diagrams/malcolmjs_phone_mockup.draw-io.png
     :align: center
 
     MalcolmJS mobile view
@@ -78,7 +78,7 @@ The mobile view is simply intended to give engineers a quick view on the informa
 Components
 ############
 
-.. figure:: architecture_diagrams/malcolmjs_components.png
+.. figure:: architecture_diagrams/malcolmjs_components.draw-io.png
     :align: center
 
     MalcolmJS component view
@@ -86,7 +86,7 @@ Components
 - **Malcolm Interface**
     The Malcolm Interface consists of all the parts needed to integrate it in to the Redux lifecycle. It is better described by the diagram below:
 
-	.. figure:: architecture_diagrams/malcolmjs_redux_integration.png
+	.. figure:: architecture_diagrams/malcolmjs_redux_integration.draw-io.png
 	    :align: center
 
 	    Malcolm redux integration
@@ -109,7 +109,7 @@ Deployment View
 
 The primary deployment scenario is where MalcolmJS is packaged up with Malcolm and served from a web server inside Malcolm on the same PANDA box. The websocket connection is to the same server, so there should be no cross-origin issues. During development we'll introduce a proxy when connecting to a test instance.
 
-.. figure:: architecture_diagrams/malcolmjs_deployment.png
+.. figure:: architecture_diagrams/malcolmjs_deployment.draw-io.png
     :align: center
 
     Serving MalcolmJS from the same server as Malcolm

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.graphviz',
-    'sphinx.ext.autosectionlabel'
 ]
 
 autoclass_content = "both"

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -22,6 +22,7 @@ Contents
     SMG/maintenance
     SMG/deployment
     SMG/troubleshooting
+    SMG/MUI_theming
 
    
 .. toctree::

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,9 @@ const theme = createMuiTheme({
   palette: {
     type: 'dark',
   },
+  alarmState: {
+    warning: '#e6c01c',
+  },
 });
 
 ReactDOM.render(

--- a/src/malcolmWidgets/attributeDetails/__snapshots__/attributeDetails.test.js.snap
+++ b/src/malcolmWidgets/attributeDetails/__snapshots__/attributeDetails.test.js.snap
@@ -4,7 +4,7 @@ exports[`AttributeDetails renders correctly 1`] = `
 <div
   className="AttributeDetails-div-1"
 >
-  <AttributeAlarm
+  <WithTheme(AttributeAlarm)
     alarmSeverity={0}
   />
   <WithStyles(Typography)

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/__snapshots__/attributeAlarm.test.js.snap
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/__snapshots__/attributeAlarm.test.js.snap
@@ -2,37 +2,41 @@
 
 exports[`AttributeAlarm renders invalid_alarm correctly 1`] = `
 <pure(HighlightOff)
-  nativeColor="#573c8b"
+  nativeColor="#303f9f"
 />
 `;
 
 exports[`AttributeAlarm renders major_alarm correctly 1`] = `
 <pure(Error)
-  nativeColor="#c01a19"
+  nativeColor="#f44336"
 />
 `;
 
 exports[`AttributeAlarm renders minor_alarm correctly 1`] = `
 <pure(Warning)
-  nativeColor="#ffd42a"
+  nativeColor="#fff"
 />
 `;
 
 exports[`AttributeAlarm renders no_alarm correctly 1`] = `
 <pure(InfoOutline)
-  nativeColor="#72a7cf"
+  nativeColor="#7986cb"
 />
 `;
 
 exports[`AttributeAlarm renders pending correctly 1`] = `
 <WithStyles(CircularProgress)
-  color="secondary"
   size={24}
+  style={
+    Object {
+      "color": "#ff4081",
+    }
+  }
 />
 `;
 
 exports[`AttributeAlarm renders undefined_alarm correctly 1`] = `
 <pure(HighlightOff)
-  nativeColor="#573c8b"
+  nativeColor="#303f9f"
 />
 `;

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Warning, Error, InfoOutline, HighlightOff } from '@material-ui/icons';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import { withTheme } from '@material-ui/core/styles/index';
 
 export const AlarmStates = {
   NO_ALARM: 0,
@@ -15,22 +16,27 @@ export const AlarmStates = {
 const AttributeAlarm = props => {
   switch (props.alarmSeverity) {
     case AlarmStates.NO_ALARM:
-      return <InfoOutline nativeColor="#72a7cf" />;
+      return <InfoOutline nativeColor={props.theme.palette.primary.light} />;
 
     case AlarmStates.MINOR_ALARM:
-      return <Warning nativeColor="#ffd42a" />;
+      return <Warning nativeColor={props.theme.alarmState.warning} />;
 
     case AlarmStates.MAJOR_ALARM:
-      return <Error nativeColor="#c01a19" />;
+      return <Error nativeColor={props.theme.palette.error.main} />;
 
     case AlarmStates.INVALID_ALARM:
-      return <HighlightOff nativeColor="#573c8b" />;
+      return <HighlightOff nativeColor={props.theme.palette.primary.dark} />;
 
     case AlarmStates.UNDEFINED_ALARM:
-      return <HighlightOff nativeColor="#573c8b" />;
+      return <HighlightOff nativeColor={props.theme.palette.primary.dark} />;
 
     case AlarmStates.PENDING:
-      return <CircularProgress size={24} color="secondary" />;
+      return (
+        <CircularProgress
+          size={24}
+          style={{ color: props.theme.palette.secondary.light }}
+        />
+      );
 
     default:
       return <div />;
@@ -39,6 +45,7 @@ const AttributeAlarm = props => {
 
 AttributeAlarm.propTypes = {
   alarmSeverity: PropTypes.number,
+  theme: PropTypes.shape({}),
 };
 
-export default AttributeAlarm;
+export default withTheme()(AttributeAlarm);

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.test.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.test.js
@@ -6,7 +6,7 @@ describe('AttributeAlarm', () => {
   let shallow;
 
   beforeEach(() => {
-    shallow = createShallow();
+    shallow = createShallow({ dive: true });
   });
 
   it('renders no_alarm correctly', () => {
@@ -18,7 +18,10 @@ describe('AttributeAlarm', () => {
 
   it('renders minor_alarm correctly', () => {
     const wrapper = shallow(
-      <AttributeAlarm alarmSeverity={AlarmStates.MINOR_ALARM} />
+      <AttributeAlarm
+        alarmSeverity={AlarmStates.MINOR_ALARM}
+        theme={{ alarmState: { warning: '#fff' } }}
+      />
     );
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { blue } from '@material-ui/core/colors';
 
 const req = require.context('../', true, /\.stories\.js$/);
 
 const theme = createMuiTheme({
   palette: {
     type: 'dark',
-    primary: blue,
+  },
+  alarmState: {
+    warning: '#e6c01c',
   },
 });
 


### PR DESCRIPTION
## Description

Added some docs on theming in material-ui and edited alarm widget to take it's colours from the theme.

## Testing instructions

- Review code
- Check Travis build
- Review changes to test coverage
- npm run storybook
- check new alarm styles in attributedDetails stories
- make clean && make docs
- open index.html under docs/build/html and view new docs entries

## Agile board tracking

connect to #74 
