### PR TITLE
Bugfix/mesageIDtracking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const history = createHistory();
 const router = routerMiddleware(history);
 
 const webSocket = new MalcolmReconnector(
-  'ws://localhost:8000/ws',
+  'ws://localhost:8008/ws',
   5000,
   WebSocket
 );

--- a/src/malcolm/malcolm.types.js
+++ b/src/malcolm/malcolm.types.js
@@ -9,3 +9,4 @@ export const MalcolmSnackbar = 'malcolm:snackbar';
 export const MalcolmNavigationPathUpdate = 'malcolm:navigationpaths';
 export const MalcolmCleanBlocks = 'malcolm:cleanblocks';
 export const MalcolmDisconnected = 'malcolm:disconnect';
+export const MalcolmReturn = 'malcolm:return';

--- a/src/malcolm/malcolmActionCreators.js
+++ b/src/malcolm/malcolmActionCreators.js
@@ -6,6 +6,7 @@ import {
   MalcolmNavigationPathUpdate,
   MalcolmCleanBlocks,
   MalcolmDisconnected,
+  MalcolmReturn,
 } from './malcolm.types';
 
 export const malcolmGetAction = path => ({
@@ -72,6 +73,13 @@ export const malcolmCleanBlocks = () => ({
 
 export const malcolmSetDisconnected = () => ({
   type: MalcolmDisconnected,
+});
+
+export const malcolmHailReturn = id => ({
+  type: MalcolmReturn,
+  payload: {
+    id,
+  },
 });
 
 export default {

--- a/src/malcolm/malcolmReconnector.js
+++ b/src/malcolm/malcolmReconnector.js
@@ -1,4 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
+// Takes a constructor for a webSocket-like object and adds some simple reconnection behaviour,
+// whilst exposing the same methods/attributes as a standard webSocket to the rest of malcolmJS
 
 class MalcolmReconnector {
   constructor(url, reconnectInterval, connectionGenerator) {

--- a/src/malcolm/malcolmSocket.js
+++ b/src/malcolm/malcolmSocket.js
@@ -1,5 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
 
+// Takes a webSocket-like object and wraps it with a queue and some simple methods
+
 class MalcolmSocketContainer {
   constructor(webSocket) {
     this.socket = webSocket;

--- a/src/malcolm/malcolmSocketHandler.js
+++ b/src/malcolm/malcolmSocketHandler.js
@@ -8,6 +8,7 @@ import {
   malcolmCleanBlocks,
   malcolmSetDisconnected,
   malcolmSetPending,
+  malcolmHailReturn,
 } from './malcolmActionCreators';
 import { MalcolmAttributeData } from './malcolm.types';
 import MalcolmReconnector from './malcolmReconnector';
@@ -176,6 +177,7 @@ const configureMalcolmSocketHandlers = (inputSocketContainer, store) => {
           .getState()
           .malcolm.messagesInFlight.find(m => m.id === data.id);
         store.dispatch(malcolmSetPending(originalRequest.path, false));
+        store.dispatch(malcolmHailReturn(data.id));
         break;
       }
 
@@ -193,6 +195,7 @@ const configureMalcolmSocketHandlers = (inputSocketContainer, store) => {
               } for block ${originalRequest.path.slice(0, -1)}`
             )
           );
+          store.dispatch(malcolmHailReturn(data.id));
           break;
         } else {
           store.dispatch(

--- a/src/malcolm/malcolmSocketHandler.test.js
+++ b/src/malcolm/malcolmSocketHandler.test.js
@@ -6,6 +6,7 @@ import {
   MalcolmCleanBlocks,
   MalcolmDisconnected,
   MalcolmRootBlockMeta,
+  MalcolmReturn,
 } from './malcolm.types';
 
 describe('malcolm socket handler', () => {
@@ -218,15 +219,17 @@ describe('malcolm socket handler', () => {
       message: 'Error: this is a test!',
     });
     socketContainer.socket.send(malcolmError);
-    expect(dispatches.length).toEqual(1);
+    expect(dispatches.length).toEqual(2);
     expect(dispatches[0].type).toEqual(MalcolmSnackbar);
     expect(dispatches[0].snackbar.open).toEqual(true);
     expect(dispatches[0].snackbar.message).toEqual(
       'Error in attribute TestAttr for block TestBlock'
     );
+    expect(dispatches[1].type).toEqual(MalcolmReturn);
+    expect(dispatches[1].payload.id).toEqual(3);
   });
 
-  it('disptaches remove pending action on return', () => {
+  it('disptaches remove pending + stop tracking actions on return', () => {
     const pendingAction = {
       payload: {
         path: ['TestBlock', 'TestAttr'],
@@ -234,13 +237,15 @@ describe('malcolm socket handler', () => {
       },
       type: 'malcolm:attributepending',
     };
-    const malcolmReturn = JSON.stringify({
+    const malcolmReturnMessage = JSON.stringify({
       typeid: 'malcolm:core/Return:1.0',
       id: 3,
     });
-    socketContainer.socket.send(malcolmReturn);
-    expect(dispatches.length).toEqual(1);
+    socketContainer.socket.send(malcolmReturnMessage);
+    expect(dispatches.length).toEqual(2);
     expect(dispatches[0]).toEqual(pendingAction);
+    expect(dispatches[1].type).toEqual(MalcolmReturn);
+    expect(dispatches[1].payload.id).toEqual(3);
   });
 
   it('only processes an update for the root .blocks item', () => {

--- a/src/malcolm/middleware/malcolmReduxMiddleware.test.js
+++ b/src/malcolm/middleware/malcolmReduxMiddleware.test.js
@@ -23,6 +23,7 @@ describe('malcolm redux middleware', () => {
   };
   let middleware = {};
   let store = {};
+  let malcolmState;
   const messagesInFlight = [];
   const next = () => 'next called';
 
@@ -30,13 +31,12 @@ describe('malcolm redux middleware', () => {
     socketMessages = [];
     dispatches = [];
     middleware = buildMalcolmReduxMiddleware(socketContainer);
-
+    malcolmState = {
+      messagesInFlight,
+      counter: 0,
+    };
     store = {
-      getState: () => ({
-        malcolm: {
-          messagesInFlight,
-        },
-      }),
+      getState: () => ({ malcolm: malcolmState }),
       dispatch: action => dispatches.push(action),
     };
   });
@@ -87,9 +87,9 @@ describe('malcolm redux middleware', () => {
     };
 
     messagesInFlight.push({ id: 1, path: ['PANDA1'] });
-    messagesInFlight.push({ id: 3, path: ['PANDA2'] });
+    messagesInFlight.push({ id: 2, path: ['PANDA2'] });
     messagesInFlight.push({ id: 5, path: ['PANDA3'] });
-
+    malcolmState.counter = 5;
     middleware(store)(next)(action);
 
     expect(socketMessages.length).toEqual(1);
@@ -101,12 +101,16 @@ describe('malcolm redux middleware', () => {
     const action = {
       type: 'malcolm:send',
       payload: {
-        typeid: 'malcolm:core/Get:1.0',
+        typeid: 'malcolm:core/Subscribe:1.0',
         path: ['PANDA'],
       },
     };
 
-    messagesInFlight.push({ id: 1, path: ['PANDA'] });
+    messagesInFlight.push({
+      id: 1,
+      typeid: 'malcolm:core/Subscribe:1.0',
+      path: ['PANDA'],
+    });
 
     middleware(store)(next)(action);
 

--- a/src/malcolm/reducer/malcolmReducer.js
+++ b/src/malcolm/reducer/malcolmReducer.js
@@ -10,6 +10,7 @@ import {
   MalcolmCleanBlocks,
   MalcolmDisconnected,
   MalcolmRootBlockMeta,
+  MalcolmReturn,
 } from '../malcolm.types';
 import { AlarmStates } from '../../malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component';
 import NavigationReducer from './navigation.reducer';
@@ -17,6 +18,7 @@ import AttributeReducer from './attribute.reducer';
 
 const initialMalcolmState = {
   messagesInFlight: [],
+  messageCounter: 0,
   navigation: [],
   blocks: {},
   parentBlock: undefined,
@@ -31,6 +33,7 @@ function updateMessagesInFlight(state, action) {
   const newState = state;
 
   if (
+    action.payload.typeid !== 'malcolm:core/Subscribe:1.0' ||
     !state.messagesInFlight.some(
       m => m.path.join() === action.payload.path.join()
     )
@@ -194,6 +197,7 @@ function setDisconnected(state) {
   return {
     ...state,
     blocks,
+    counter: 0,
   };
 }
 
@@ -209,6 +213,9 @@ const malcolmReducer = (state = initialMalcolmState, action) => {
       return updateMessagesInFlight(state, action);
 
     case MalcolmError:
+      return stopTrackingMessage(state, action);
+
+    case MalcolmReturn:
       return stopTrackingMessage(state, action);
 
     case MalcolmBlockMeta:

--- a/src/malcolm/reducer/malcolmReducer.test.js
+++ b/src/malcolm/reducer/malcolmReducer.test.js
@@ -21,7 +21,7 @@ const buildAction = (type, id, path = ['.', 'blocks']) => ({
   type,
   payload: {
     id,
-    typeid: 'malcolm:core/Get:1.0',
+    typeid: 'malcolm:core/Subscribe:1.0',
     path,
   },
 });
@@ -66,7 +66,9 @@ describe('malcolm reducer', () => {
 
     expect(newState.messagesInFlight.length).toEqual(1);
     expect(newState.messagesInFlight[0].type).not.toBeDefined();
-    expect(newState.messagesInFlight[0].typeid).toEqual('malcolm:core/Get:1.0');
+    expect(newState.messagesInFlight[0].typeid).toEqual(
+      'malcolm:core/Subscribe:1.0'
+    );
   });
 
   it('tracks multiple malcolm messages in the state', () => {
@@ -76,11 +78,18 @@ describe('malcolm reducer', () => {
     expect(state.messagesInFlight.length).toEqual(2);
   });
 
-  it('does not tracks multiple malcolm messages with the same path', () => {
+  it('does not tracks multiple malcolm subscriptions with the same path', () => {
     state = malcolmReducer(state, buildAction('malcolm:send', 1));
-    state = malcolmReducer(state, buildAction('malcolm:send', 1));
-
+    state = malcolmReducer(state, buildAction('malcolm:send', 2));
     expect(state.messagesInFlight.length).toEqual(1);
+  });
+
+  it('does track multiple malcolm non-subscription messages with the same path', () => {
+    state = malcolmReducer(state, buildAction('malcolm:send', 1));
+    const malcolmGetAction = buildAction('malcolm:send', 2);
+    malcolmGetAction.payload.typeid = 'malcolm:core/Get:1.0';
+    state = malcolmReducer(state, malcolmGetAction);
+    expect(state.messagesInFlight.length).toEqual(2);
   });
 
   it('stops tracking a message once an error response is received', () => {
@@ -89,6 +98,17 @@ describe('malcolm reducer', () => {
     };
 
     const newState = malcolmReducer(state, buildAction('malcolm:error', 1));
+
+    expect(newState.messagesInFlight.length).toEqual(1);
+    expect(newState.messagesInFlight[0].id).toEqual(123);
+  });
+
+  it('stops tracking a message once an return response is received', () => {
+    state = {
+      messagesInFlight: [{ id: 1 }, { id: 123 }],
+    };
+
+    const newState = malcolmReducer(state, buildAction('malcolm:return', 1));
 
     expect(newState.messagesInFlight.length).toEqual(1);
     expect(newState.messagesInFlight[0].id).toEqual(123);


### PR DESCRIPTION
## Description

Fixed bug with message ID tracking which was preventing the sending of PUTs to a path which was already subscribed to (instead of just preventing a duplicate subscription to that path) 


