### PR TITLE
Basic text input widget

### DIFF
--- a/src/malcolmWidgets/textInput/WidgetTextInput.component.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.component.js
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import TextField from '@material-ui/core/TextField';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import { withStyles } from '@material-ui/core/styles';
+import { emphasize } from '@material-ui/core/styles/colorManipulator';
+
+const styles = theme => ({
+  textInput: {
+    backgroundColor: emphasize(theme.palette.background.paper, 0.1),
+  },
+  inputStyle: {
+    padding: 5,
+    fontSize: '11pt',
+    textAlign: 'Right',
+  },
+  InputStyle: {
+    paddingRight: 4,
+  },
+});
+
+class WidgetTextInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      localValue: props.Value,
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(event) {
+    this.setState({
+      localValue: event.target.value,
+    });
+  }
+
+  render() {
+    return (
+      <TextField
+        disabled={this.props.Pending}
+        value={this.state.localValue}
+        onChange={this.handleChange}
+        onKeyPress={this.props.submitEventHandler}
+        onBlur={this.props.blurHandler}
+        onFocus={this.props.focusHandler}
+        className={this.props.classes.textInput}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">{this.props.Units}</InputAdornment>
+          ),
+          className: this.props.classes.InputStyle,
+        }}
+        // eslint-disable-next-line react/jsx-no-duplicate-props
+        inputProps={{ className: this.props.classes.inputStyle }}
+      />
+    );
+  }
+}
+
+WidgetTextInput.propTypes = {
+  Value: PropTypes.string.isRequired,
+  submitEventHandler: PropTypes.func.isRequired,
+  blurHandler: PropTypes.func.isRequired,
+  focusHandler: PropTypes.func.isRequired,
+  Pending: PropTypes.bool,
+  Units: PropTypes.string,
+  classes: PropTypes.shape({
+    textInput: PropTypes.string,
+    InputStyle: PropTypes.string,
+    inputStyle: PropTypes.string,
+  }).isRequired,
+};
+
+WidgetTextInput.defaultProps = {
+  Pending: false,
+  Units: null,
+};
+
+export default withStyles(styles, { withTheme: true })(WidgetTextInput);

--- a/src/malcolmWidgets/textInput/WidgetTextInput.stories.container.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.stories.container.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+
+import WidgetTextInput from './WidgetTextInput.component';
+
+const styles = theme => ({
+  div: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    backgroundColor: theme.palette.background.paper,
+    width: 148,
+    padding: 10,
+  },
+});
+
+const ContainedTextInput = props => (
+  <div className={props.classes.div}>
+    <WidgetTextInput
+      Value={props.Value}
+      Pending={props.Pending}
+      submitEventHandler={props.submitEventHandler}
+      focusHandler={props.focusHandler}
+      blurHandler={props.blurHandler}
+      Units={props.Units}
+    />
+  </div>
+);
+
+ContainedTextInput.propTypes = {
+  Value: PropTypes.string.isRequired,
+  submitEventHandler: PropTypes.func.isRequired,
+  blurHandler: PropTypes.func.isRequired,
+  focusHandler: PropTypes.func.isRequired,
+  Pending: PropTypes.bool,
+  Units: PropTypes.string,
+  classes: PropTypes.shape({
+    div: PropTypes.string,
+  }).isRequired,
+};
+
+ContainedTextInput.defaultProps = {
+  Pending: false,
+  Units: null,
+};
+
+export default withStyles(styles, { withTheme: true })(ContainedTextInput);

--- a/src/malcolmWidgets/textInput/WidgetTextInput.stories.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.stories.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
+
+import ContainedTextInput from './WidgetTextInput.stories.container';
+
+const submitAction = action('submitted:');
+
+const submitEvent = event => {
+  if (event.key === 'Enter') {
+    submitAction(event.target.value);
+  }
+};
+
+const checkbox = (value, pending, units) => (
+  <ContainedTextInput
+    Value={value}
+    Pending={pending}
+    submitEventHandler={submitEvent}
+    focusHandler={action('focused')}
+    blurHandler={action('blurred')}
+    Units={units}
+  />
+);
+
+storiesOf('Widgets/textinput', module)
+  .add(
+    'simple',
+    withInfo(`
+  textinput.
+  `)(() => checkbox('someText', false, null))
+  )
+  .add(
+    'with units',
+    withInfo(`
+  textinput.
+  `)(() => checkbox('1.21', false, 'GW'))
+  )
+  .add(
+    'disabled',
+    withInfo(`
+  textinput.
+  `)(() => checkbox('someText', true, null))
+  );

--- a/src/malcolmWidgets/textInput/WidgetTextInput.test.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import WidgetTextInput from './WidgetTextInput.component';
+
+const textInput = (value, pending, units) => (
+  <WidgetTextInput
+    Value={value}
+    Pending={pending}
+    submitEventHandler={() => {}}
+    focusHandler={() => {}}
+    blurHandler={() => {}}
+    Units={units}
+  />
+);
+
+describe('WidgetTextUpdate', () => {
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow({ dive: true });
+  });
+
+  it('displays text', () => {
+    const wrapper = shallow(textInput('Hello World', false, null));
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('displays with units', () => {
+    const wrapper = shallow(textInput('1.21', false, 'GW'));
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('displays disabled', () => {
+    const wrapper = shallow(textInput('Goodbye World', true, null));
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/malcolmWidgets/textInput/__snapshots__/WidgetTextInput.test.js.snap
+++ b/src/malcolmWidgets/textInput/__snapshots__/WidgetTextInput.test.js.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WidgetTextUpdate displays disabled 1`] = `
+<TextField
+  InputProps={
+    Object {
+      "className": "WidgetTextInput-InputStyle-3",
+      "endAdornment": <WithStyles(InputAdornment)
+        position="end"
+    />,
+    }
+  }
+  className="WidgetTextInput-textInput-1"
+  disabled={true}
+  inputProps={
+    Object {
+      "className": "WidgetTextInput-inputStyle-2",
+    }
+  }
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  required={false}
+  select={false}
+  value="Goodbye World"
+/>
+`;
+
+exports[`WidgetTextUpdate displays text 1`] = `
+<TextField
+  InputProps={
+    Object {
+      "className": "WidgetTextInput-InputStyle-3",
+      "endAdornment": <WithStyles(InputAdornment)
+        position="end"
+    />,
+    }
+  }
+  className="WidgetTextInput-textInput-1"
+  disabled={false}
+  inputProps={
+    Object {
+      "className": "WidgetTextInput-inputStyle-2",
+    }
+  }
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  required={false}
+  select={false}
+  value="Hello World"
+/>
+`;
+
+exports[`WidgetTextUpdate displays with units 1`] = `
+<TextField
+  InputProps={
+    Object {
+      "className": "WidgetTextInput-InputStyle-3",
+      "endAdornment": <WithStyles(InputAdornment)
+        position="end"
+    >
+        GW
+    </WithStyles(InputAdornment)>,
+    }
+  }
+  className="WidgetTextInput-textInput-1"
+  disabled={false}
+  inputProps={
+    Object {
+      "className": "WidgetTextInput-inputStyle-2",
+    }
+  }
+  onBlur={[Function]}
+  onChange={[Function]}
+  onFocus={[Function]}
+  onKeyPress={[Function]}
+  required={false}
+  select={false}
+  value="1.21"
+/>
+`;


### PR DESCRIPTION
## Description

text input widget, uses material-ui TextField and takes callbacks for keypress, blur/deselect and focus/select events.

## Testing instructions

- Review code
- Check Travis build
- Review changes to test coverage
- npm run storybook
- examine the widget

## Agile board tracking

connect to #26 
