### PR TITLE
Added truncation to textUpdate widget

### DIFF
--- a/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
@@ -84,9 +84,9 @@ const AttributeSelector = props => {
 const mapStateToProps = () => ({});
 
 const mapDispatchToProps = dispatch => ({
-  eventHandler: (path, isChecked) => {
+  eventHandler: (path, value) => {
     dispatch(malcolmSetPending(path, true));
-    dispatch(malcolmPutAction(path, isChecked));
+    dispatch(malcolmPutAction(path, value));
   },
 });
 

--- a/src/malcolmWidgets/textUpdate/WidgetTextUpdate.component.js
+++ b/src/malcolmWidgets/textUpdate/WidgetTextUpdate.component.js
@@ -14,7 +14,7 @@ const styles = theme => ({
 });
 
 const WidgetTextUpdate = props => (
-  <Typography className={props.classes.textUpdate}>
+  <Typography className={props.classes.textUpdate} noWrap>
     {props.Text} {props.Units ? props.Units : null}
   </Typography>
 );

--- a/src/malcolmWidgets/textUpdate/WidgetTextUpdate.component.js
+++ b/src/malcolmWidgets/textUpdate/WidgetTextUpdate.component.js
@@ -5,25 +5,63 @@ import Typography from '@material-ui/core/Typography';
 import { emphasize } from '@material-ui/core/styles/colorManipulator';
 
 const styles = theme => ({
-  textUpdate: {
+  div: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  textUpdate80: {
+    backgroundColor: emphasize(theme.palette.background.paper, 0.1),
+    padding: 4,
+    paddingRight: 9,
+    textAlign: 'Right',
+    width: '80%',
+  },
+  textUpdate100: {
     backgroundColor: emphasize(theme.palette.background.paper, 0.1),
     padding: 4,
     paddingRight: 16,
     textAlign: 'Right',
+    width: '100%',
+  },
+  unitBox: {
+    backgroundColor: emphasize(theme.palette.background.paper, 0.1),
+    color: emphasize(theme.palette.primary.contrastText, 0.2),
+    padding: 4,
+    paddingRight: 2,
+    width: '20%',
   },
 });
 
-const WidgetTextUpdate = props => (
-  <Typography className={props.classes.textUpdate} noWrap>
-    {props.Text} {props.Units ? props.Units : null}
-  </Typography>
-);
+const WidgetTextUpdate = props => {
+  if (!props.Units) {
+    return (
+      <div className={props.classes.div}>
+        <Typography className={props.classes.textUpdate100} noWrap>
+          {props.Text}
+        </Typography>
+      </div>
+    );
+  }
+  return (
+    <div className={props.classes.div}>
+      <Typography className={props.classes.textUpdate80} noWrap>
+        {props.Text}
+      </Typography>
+      <Typography className={props.classes.unitBox} noWrap>
+        {props.Units}
+      </Typography>
+    </div>
+  );
+};
 
 WidgetTextUpdate.propTypes = {
   Text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   Units: PropTypes.string,
   classes: PropTypes.shape({
-    textUpdate: PropTypes.string,
+    textUpdate100: PropTypes.string,
+    textUpdate80: PropTypes.string,
+    unitBox: PropTypes.string,
+    div: PropTypes.string,
   }).isRequired,
 };
 

--- a/src/malcolmWidgets/textUpdate/WidgetTextUpdate.stories.js
+++ b/src/malcolmWidgets/textUpdate/WidgetTextUpdate.stories.js
@@ -27,4 +27,26 @@ storiesOf('Widgets/WidgetTextUpdate', module)
     withInfo(`
   A simple field for displaying some text (with units).
   `)(() => TextUpdate(1.21, 'GW'))
+  )
+  .add(
+    'truncated text',
+    withInfo(`
+  A simple field for displaying some text (truncated text).
+  `)(() =>
+      TextUpdate(
+        '3.1415926535 8979323846 2643383279 5028841971 6939937510 5820974944 5923078164 0628620899 8628034825 3421170679',
+        null
+      )
+    )
+  )
+  .add(
+    'truncated text with units',
+    withInfo(`
+  A simple field for displaying some text (truncated text).
+  `)(() =>
+      TextUpdate(
+        '3.1415926535 8979323846 2643383279 5028841971 6939937510 5820974944 5923078164 0628620899 8628034825 3421170679',
+        'rad'
+      )
+    )
   );

--- a/src/malcolmWidgets/textUpdate/__snapshots__/WidgetTextUpdate.test.js.snap
+++ b/src/malcolmWidgets/textUpdate/__snapshots__/WidgetTextUpdate.test.js.snap
@@ -3,6 +3,7 @@
 exports[`WidgetTextUpdate displays text 1`] = `
 <WithStyles(Typography)
   className="WidgetTextUpdate-textUpdate-1"
+  noWrap={true}
 >
   Hello World
    
@@ -12,6 +13,7 @@ exports[`WidgetTextUpdate displays text 1`] = `
 exports[`WidgetTextUpdate displays with units 1`] = `
 <WithStyles(Typography)
   className="WidgetTextUpdate-textUpdate-1"
+  noWrap={true}
 >
   1.21
    

--- a/src/malcolmWidgets/textUpdate/__snapshots__/WidgetTextUpdate.test.js.snap
+++ b/src/malcolmWidgets/textUpdate/__snapshots__/WidgetTextUpdate.test.js.snap
@@ -1,22 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WidgetTextUpdate displays text 1`] = `
-<WithStyles(Typography)
-  className="WidgetTextUpdate-textUpdate-1"
-  noWrap={true}
+<div
+  className="WidgetTextUpdate-div-1"
 >
-  Hello World
-   
-</WithStyles(Typography)>
+  <WithStyles(Typography)
+    className="WidgetTextUpdate-textUpdate100-3"
+    noWrap={true}
+  >
+    Hello World
+  </WithStyles(Typography)>
+</div>
 `;
 
 exports[`WidgetTextUpdate displays with units 1`] = `
-<WithStyles(Typography)
-  className="WidgetTextUpdate-textUpdate-1"
-  noWrap={true}
+<div
+  className="WidgetTextUpdate-div-1"
 >
-  1.21
-   
-  GW
-</WithStyles(Typography)>
+  <WithStyles(Typography)
+    className="WidgetTextUpdate-textUpdate75-2"
+    noWrap={true}
+  >
+    1.21
+  </WithStyles(Typography)>
+  <WithStyles(Typography)
+    className="WidgetTextUpdate-unitBox-4"
+    noWrap={true}
+  >
+    GW
+  </WithStyles(Typography)>
+</div>
 `;

--- a/src/malcolmWidgets/textUpdate/__snapshots__/WidgetTextUpdate.test.js.snap
+++ b/src/malcolmWidgets/textUpdate/__snapshots__/WidgetTextUpdate.test.js.snap
@@ -18,7 +18,7 @@ exports[`WidgetTextUpdate displays with units 1`] = `
   className="WidgetTextUpdate-div-1"
 >
   <WithStyles(Typography)
-    className="WidgetTextUpdate-textUpdate75-2"
+    className="WidgetTextUpdate-textUpdate80-2"
     noWrap={true}
   >
     1.21


### PR DESCRIPTION
## Description
Material-UI typography object has "noWrap" property, which truncates text instead of wrapping or resizing typography object (this property has now been set to true for the textUpdate widget)

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm run storybook
- view truncated text story

## Agile board tracking

connect to #123
