### PR TITLE
Updated the nav bar so it can use labels for friendly names

### DIFF
--- a/src/malcolm/reducer/navigation.reducer.js
+++ b/src/malcolm/reducer/navigation.reducer.js
@@ -3,6 +3,7 @@ export const processNavigationLists = (paths, blocks) => {
     path: p,
     children: [],
     basePath: '/',
+    label: p,
   }));
 
   if (navigationLists.length === 0) {
@@ -10,6 +11,7 @@ export const processNavigationLists = (paths, blocks) => {
       path: '',
       children: [],
       basePath: '/',
+      label: '',
     });
   }
 
@@ -31,6 +33,7 @@ export const processNavigationLists = (paths, blocks) => {
     if (Object.prototype.hasOwnProperty.call(blocks, path)) {
       previousBlock = blocks[path];
       navigationLists[i].children = previousBlock.children;
+      navigationLists[i].label = i === 0 ? path : previousBlock.label;
     } else if (previousBlock && previousBlock.attributes) {
       const matchingAttribute = previousBlock.attributes.findIndex(
         a => a.name === path
@@ -39,6 +42,8 @@ export const processNavigationLists = (paths, blocks) => {
         const attribute = previousBlock.attributes[matchingAttribute];
         navigationLists[i].children = attribute.children;
       }
+
+      navigationLists[i].label = path;
     }
 
     navigationLists[i].basePath = basePath;

--- a/src/malcolm/reducer/navigation.reducer.test.js
+++ b/src/malcolm/reducer/navigation.reducer.test.js
@@ -49,6 +49,7 @@ describe('processNavigationLists', () => {
         children: ['block1', 'block2'],
       },
       block1: {
+        label: 'block 1',
         attributes: [
           {
             name: 'layout',
@@ -58,6 +59,7 @@ describe('processNavigationLists', () => {
         children: ['block2'],
       },
       block2: {
+        label: 'block 2',
         children: ['block3', 'block4'],
       },
     };
@@ -76,9 +78,11 @@ describe('processNavigationLists', () => {
 
     expect(navLists).toHaveLength(2);
     expect(navLists[0].path).toBe('block1');
+    expect(navLists[0].label).toBe('block1');
     expect(navLists[0].children).toBe(blocks.block1.children);
 
     expect(navLists[1].path).toBe('block2');
+    expect(navLists[1].label).toBe('block 2');
     expect(navLists[1].children).toBe(blocks.block2.children);
   });
 
@@ -88,12 +92,15 @@ describe('processNavigationLists', () => {
 
     expect(navLists).toHaveLength(3);
     expect(navLists[0].path).toBe('block1');
+    expect(navLists[0].label).toBe('block1');
     expect(navLists[0].children).toBe(blocks.block1.children);
 
     expect(navLists[1].path).toBe('layout');
+    expect(navLists[1].label).toBe('layout');
     expect(navLists[1].children).toEqual(['block5', 'block6']);
 
     expect(navLists[2].path).toBe('block3');
+    expect(navLists[2].label).toBe('block3');
     expect(navLists[2].children).toHaveLength(0);
   });
 });

--- a/src/navbar/navcontrol.component.js
+++ b/src/navbar/navcontrol.component.js
@@ -46,7 +46,7 @@ class NavControl extends Component {
           className={classes.currentLink}
           onClick={() => navigateToChild('')}
         >
-          {nav.path}
+          {nav.label}
         </Typography>
         <IconButton
           onClick={this.handleClick}

--- a/src/navbar/navcontrol.test.js
+++ b/src/navbar/navcontrol.test.js
@@ -7,8 +7,9 @@ describe('NavControl', () => {
   let mount;
 
   const nav = {
-    path: 'PANDA',
+    path: 'PANDA:mri',
     children: ['layout', 'table'],
+    label: 'PANDA',
   };
 
   beforeEach(() => {


### PR DESCRIPTION
## Description

Updated the navigation lists so they also have a label, this means we can display `TTL input 1` rather than `PANDA:TTLIN1`

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- run `npm start` and navigate to http://localhost:3000/gui/PANDA/layout/PANDA:TTLIN1/

## Agile board tracking

connect to #127 

