### PR TITLE
Moved textInput dirty icon to attribute alarm icon

### DIFF
--- a/src/malcolm/reducer/malcolmReducer.js
+++ b/src/malcolm/reducer/malcolmReducer.js
@@ -210,6 +210,9 @@ function setFlag(state, path, flagType, flagState) {
     const attributes = [...state.blocks[blockName].attributes];
     const attributeCopy = {
       ...attributes[matchingAttribute],
+      calculated: {
+        ...attributes[matchingAttribute].calculated,
+      },
     };
     // #refactorDuplication
     // if (attributeCopy.calculated) {

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/__snapshots__/attributeAlarm.test.js.snap
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/__snapshots__/attributeAlarm.test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`AttributeAlarm renders blank if no alarm severity specified 1`] = `<div />`;
 
+exports[`AttributeAlarm renders dirty correctly 1`] = `
+<pure(Edit)
+  nativeColor="#7986cb"
+/>
+`;
+
 exports[`AttributeAlarm renders invalid_alarm correctly 1`] = `
 <pure(HighlightOff)
   nativeColor="#303f9f"

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
@@ -1,6 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Warning, Error, InfoOutline, HighlightOff } from '@material-ui/icons';
+import {
+  Warning,
+  Error,
+  InfoOutline,
+  HighlightOff,
+  Edit,
+} from '@material-ui/icons';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { withTheme } from '@material-ui/core/styles/index';
 
@@ -11,6 +17,7 @@ export const AlarmStates = {
   INVALID_ALARM: 3,
   UNDEFINED_ALARM: 4,
   PENDING: -1,
+  DIRTY: -2,
 };
 
 const AttributeAlarm = props => {
@@ -37,6 +44,9 @@ const AttributeAlarm = props => {
           style={{ color: props.theme.palette.secondary.light }}
         />
       );
+
+    case AlarmStates.DIRTY:
+      return <Edit nativeColor={props.theme.palette.primary.light} />;
 
     default:
       return <div />;

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.test.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.test.js
@@ -46,9 +46,17 @@ describe('AttributeAlarm', () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
   it('renders pending correctly', () => {
     const wrapper = shallow(
       <AttributeAlarm alarmSeverity={AlarmStates.PENDING} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders dirty correctly', () => {
+    const wrapper = shallow(
+      <AttributeAlarm alarmSeverity={AlarmStates.DIRTY} />
     );
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -48,6 +48,7 @@ const AttributeDetails = props => {
   }
   if (widgetTagIndex !== null) {
     let alarm = props.attribute.raw.alarm.severity;
+    alarm = props.attribute.calculated.dirty ? AlarmStates.DIRTY : alarm;
     alarm = props.attribute.calculated.errorState
       ? AlarmStates.MAJOR_ALARM
       : alarm;
@@ -83,6 +84,7 @@ AttributeDetails.propTypes = {
       errorState: PropTypes.bool,
       errorMessage: PropTypes.string,
       unableToProcess: PropTypes.bool,
+      dirty: PropTypes.bool,
     }),
     raw: PropTypes.shape({
       meta: PropTypes.shape({

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.stories.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.stories.js
@@ -19,17 +19,21 @@ const generateInfo = alarmState => ({
 const mockStore = configureStore();
 
 const attribute = alarmStateValue => ({
-  name: 'attribute 1',
-  alarm: {
-    severity: alarmStateValue,
+  calculated: {
+    name: 'attribute 1',
   },
-  meta: {
-    writeable: false,
-    typeid: 'malcolm:core/BooleanMeta:1.0',
-    label: 'Attribute 1',
-    tags: ['widget:led'],
+  raw: {
+    alarm: {
+      severity: alarmStateValue,
+    },
+    meta: {
+      writeable: false,
+      typeid: 'malcolm:core/BooleanMeta:1.0',
+      label: 'Attribute 1',
+      tags: [alarmStateValue === -2 ? 'widget:textinput' : 'widget:led'],
+    },
+    value: true,
   },
-  value: true,
 });
 
 const buildState = alarmStateValue => ({
@@ -62,4 +66,5 @@ storiesOf('Details/Attribute Details', module)
   .add(
     'pending',
     withInfo(generateInfo('PENDING'))(() => generateComponent(-1))
-  );
+  )
+  .add('dirty', withInfo(generateInfo('DIRTY'))(() => generateComponent(-2)));

--- a/src/malcolmWidgets/textInput/WidgetTextInput.component.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.component.js
@@ -2,8 +2,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import TextField from '@material-ui/core/TextField';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import { Cached, Edit, Lock } from '@material-ui/icons';
-import IconButton from '@material-ui/core/IconButton';
 import { withStyles } from '@material-ui/core/styles';
 import { emphasize } from '@material-ui/core/styles/colorManipulator';
 
@@ -36,6 +34,9 @@ class WidgetTextInput extends React.Component {
         localValue: props.Value,
       };
     } else if (props.forceUpdate) {
+      if (props.Error) {
+        props.submitEventHandler({ target: { value: props.Value } });
+      }
       props.setFlag('forceUpdate', false);
       return {
         localValue: props.Value,
@@ -52,7 +53,6 @@ class WidgetTextInput extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.deFocus = this.deFocus.bind(this);
     this.inFocus = this.inFocus.bind(this);
-    this.refreshValue = this.refreshValue.bind(this);
     this.didSubmit = this.didSubmit.bind(this);
   }
 
@@ -66,14 +66,6 @@ class WidgetTextInput extends React.Component {
     if (this.props.continuousSend) {
       this.props.submitEventHandler(event);
     }
-  }
-
-  refreshValue() {
-    this.props.setFlag('dirty', false);
-    this.setState({
-      localValue: this.props.Value,
-    });
-    this.props.submitEventHandler({ target: { value: this.props.Value } });
   }
 
   didSubmit(event) {
@@ -95,41 +87,6 @@ class WidgetTextInput extends React.Component {
   }
 
   render() {
-    const iconColor = this.props.Error
-      ? this.props.theme.palette.error.main
-      : this.props.theme.palette.primary.light;
-
-    const dirtyIcon = () => {
-      if (this.props.Pending) {
-        return (
-          <InputAdornment position="start">
-            <Lock nativeColor={this.props.theme.palette.background.paper} />
-          </InputAdornment>
-        );
-      } else if (this.props.isDirty) {
-        return (
-          <InputAdornment position="start">
-            {this.props.Value === this.state.localValue ? (
-              <Edit nativeColor={iconColor} />
-            ) : (
-              <IconButton
-                className={this.props.classes.button}
-                disableRipple
-                onClick={this.refreshValue}
-              >
-                <Cached nativeColor={iconColor} />
-              </IconButton>
-            )}
-          </InputAdornment>
-        );
-      }
-      return (
-        <InputAdornment position="start">
-          <Edit nativeColor={this.props.theme.palette.background.paper} />
-        </InputAdornment>
-      );
-    };
-
     const endAdornment = this.props.Units ? (
       <InputAdornment position="end">{this.props.Units}</InputAdornment>
     ) : null;
@@ -146,7 +103,6 @@ class WidgetTextInput extends React.Component {
         className={this.props.classes.textInput}
         InputProps={{
           endAdornment,
-          startAdornment: dirtyIcon(),
           className: this.props.classes.InputStyle,
         }}
         // eslint-disable-next-line react/jsx-no-duplicate-props
@@ -171,19 +127,6 @@ WidgetTextInput.propTypes = {
     InputStyle: PropTypes.string,
     inputStyle: PropTypes.string,
     button: PropTypes.string,
-  }).isRequired,
-  theme: PropTypes.shape({
-    palette: PropTypes.shape({
-      background: PropTypes.shape({
-        paper: PropTypes.string,
-      }),
-      primary: PropTypes.shape({
-        light: PropTypes.string,
-      }),
-      error: PropTypes.shape({
-        main: PropTypes.string,
-      }),
-    }),
   }).isRequired,
   continuousSend: PropTypes.bool,
 };

--- a/src/malcolmWidgets/textInput/WidgetTextInput.stories.container.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.stories.container.js
@@ -25,7 +25,7 @@ const ContainedTextInput = props => (
       blurHandler={props.blurHandler}
       Units={props.Units}
       isDirty={props.isDirty}
-      setDirty={props.setDirty}
+      setFlag={props.setDirty}
     />
   </div>
 );

--- a/src/malcolmWidgets/textInput/WidgetTextInput.test.js
+++ b/src/malcolmWidgets/textInput/WidgetTextInput.test.js
@@ -9,7 +9,8 @@ const textInput = (
   isDirty,
   setFlag = () => {},
   setValue = () => {},
-  forceUpdate = false
+  forceUpdate = false,
+  error = false
 ) => (
   <WidgetTextInput
     Value={value}
@@ -21,6 +22,7 @@ const textInput = (
     isDirty={isDirty}
     setFlag={setFlag}
     forceUpdate={forceUpdate}
+    Error={error}
   />
 );
 
@@ -116,30 +118,19 @@ describe('WidgetTextUpdate', () => {
     expect(setFlag.mock.calls[0]).toEqual(['forceUpdate', false]);
   });
 
-  it('button unsets dirty and calls revert value when clicked if local state changed', () => {
-    const setDirty = jest.fn();
-    const mockData = { mock: { calls: [] } };
-    const setValue = event => {
-      mockData.mock.calls.push(event.target.value);
-    };
-    const wrapper = mount(
-      textInput('Hello World', false, null, true, setDirty, setValue)
+  it('updates, calls unset flag and sends put with last known malcolm value if forceUpdate is true and is error', () => {
+    const setFlag = jest.fn();
+    const setValue = jest.fn();
+    mount(
+      textInput('Hello World', false, null, true, setFlag, setValue, true, true)
     );
-    wrapper
-      .find('input')
-      .first()
-      .simulate('focus')
-      .find('input')
-      .first()
-      .simulate('change', { target: { value: 'test' } });
-    wrapper.update();
-    wrapper
-      .find('button')
-      .first()
-      .simulate('click');
-    expect(setDirty.mock.calls.length).toEqual(2);
-    expect(setDirty.mock.calls[1]).toEqual(['dirty', false]);
-    expect(mockData.mock.calls.length).toEqual(1);
-    expect(mockData.mock.calls[0]).toEqual('Hello World');
+    expect(setFlag.mock.calls.length).toEqual(1);
+    expect(setFlag.mock.calls[0]).toEqual(['forceUpdate', false]);
+    expect(setValue.mock.calls.length).toEqual(1);
+    expect(setValue.mock.calls[0]).toEqual([
+      {
+        target: { value: 'Hello World' },
+      },
+    ]);
   });
 });

--- a/src/malcolmWidgets/textInput/__snapshots__/WidgetTextInput.test.js.snap
+++ b/src/malcolmWidgets/textInput/__snapshots__/WidgetTextInput.test.js.snap
@@ -6,13 +6,6 @@ exports[`WidgetTextUpdate displays dirty 1`] = `
     Object {
       "className": "WidgetTextInput-InputStyle-3",
       "endAdornment": null,
-      "startAdornment": <WithStyles(InputAdornment)
-        position="start"
-    >
-        <pure(Lock)
-            nativeColor="#fff"
-        />
-    </WithStyles(InputAdornment)>,
     }
   }
   className="WidgetTextInput-textInput-1"
@@ -39,13 +32,6 @@ exports[`WidgetTextUpdate displays disabled 1`] = `
     Object {
       "className": "WidgetTextInput-InputStyle-3",
       "endAdornment": null,
-      "startAdornment": <WithStyles(InputAdornment)
-        position="start"
-    >
-        <pure(Lock)
-            nativeColor="#fff"
-        />
-    </WithStyles(InputAdornment)>,
     }
   }
   className="WidgetTextInput-textInput-1"
@@ -72,13 +58,6 @@ exports[`WidgetTextUpdate displays text 1`] = `
     Object {
       "className": "WidgetTextInput-InputStyle-3",
       "endAdornment": null,
-      "startAdornment": <WithStyles(InputAdornment)
-        position="start"
-    >
-        <pure(Edit)
-            nativeColor="#fff"
-        />
-    </WithStyles(InputAdornment)>,
     }
   }
   className="WidgetTextInput-textInput-1"
@@ -108,13 +87,6 @@ exports[`WidgetTextUpdate displays with units 1`] = `
         position="end"
     >
         GW
-    </WithStyles(InputAdornment)>,
-      "startAdornment": <WithStyles(InputAdornment)
-        position="start"
-    >
-        <pure(Edit)
-            nativeColor="#fff"
-        />
     </WithStyles(InputAdornment)>,
     }
   }


### PR DESCRIPTION
## Description

Moved dirty icon from textInput to attribute alarm icon.
Text inputs now have no start adornment.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/PANDA:SEQ1
- try out clicking and typing in the "Prescale" (or any other) text input

## Agile board tracking

connect to #224 
closes #224 