### PR TITLE
Added a new palette window for the layout view

### DIFF
--- a/src/layout/palette/__snapshots__/palette.component.test.js.snap
+++ b/src/layout/palette/__snapshots__/palette.component.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Palette renders correctly 1`] = `
+<div
+  className="Palette-container-1"
+>
+  Palette goes here
+</div>
+`;

--- a/src/layout/palette/palette.component.js
+++ b/src/layout/palette/palette.component.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+
+const styles = {
+  container: {
+    marginTop: 15,
+  },
+};
+
+const Palette = props => (
+  <div className={props.classes.container}>Palette goes here</div>
+);
+
+Palette.propTypes = {
+  classes: PropTypes.shape({
+    container: PropTypes.string,
+  }).isRequired,
+};
+
+export default withStyles(styles, { withTheme: true })(Palette);

--- a/src/layout/palette/palette.component.test.js
+++ b/src/layout/palette/palette.component.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import Palette from './palette.component';
+
+describe('Palette', () => {
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow({
+      dive: true,
+    });
+  });
+
+  it('renders correctly', () => {
+    const tree = shallow(<Palette />);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/mainMalcolmView/__snapshots__/mainMalcolmView.test.js.snap
+++ b/src/mainMalcolmView/__snapshots__/mainMalcolmView.test.js.snap
@@ -15,3 +15,37 @@ exports[`MainMalcolmView renders correctly 1`] = `
   </Connect(WithStyles(DrawerContainer))>
 </div>
 `;
+
+exports[`MainMalcolmView renders info if child block is .info 1`] = `
+<div>
+  <Connect(WithStyles(DrawerContainer))
+    childTitle="Info"
+    parentTitle="Test main view"
+    popOutAction={[Function]}
+  >
+    <Connect(WithStyles(BlockDetails))
+      parent={true}
+    />
+    <Connect(WithStyles(MiddlePanelContainer)) />
+    <div>
+      Info goes here
+    </div>
+  </Connect(WithStyles(DrawerContainer))>
+</div>
+`;
+
+exports[`MainMalcolmView renders palette if child block is .palette 1`] = `
+<div>
+  <Connect(WithStyles(DrawerContainer))
+    childTitle="Palette"
+    parentTitle="Test main view"
+    popOutAction={[Function]}
+  >
+    <Connect(WithStyles(BlockDetails))
+      parent={true}
+    />
+    <Connect(WithStyles(MiddlePanelContainer)) />
+    <WithStyles(Palette) />
+  </Connect(WithStyles(DrawerContainer))>
+</div>
+`;

--- a/src/mainMalcolmView/__snapshots__/middlePanel.container.test.js.snap
+++ b/src/mainMalcolmView/__snapshots__/middlePanel.container.test.js.snap
@@ -7,7 +7,7 @@ exports[`MalcolmMiddlePanel renders a container only if the mainAttribute is not
   role="presentation"
 >
   <div
-    className="MiddlePanelContainer-plainBackground-6"
+    className="MiddlePanelContainer-plainBackground-7"
   >
     <div
       style={
@@ -37,7 +37,7 @@ exports[`MalcolmMiddlePanel renders a container only if the no widget tag found 
   role="presentation"
 >
   <div
-    className="MiddlePanelContainer-plainBackground-6"
+    className="MiddlePanelContainer-plainBackground-7"
   >
     <div
       style={
@@ -83,6 +83,23 @@ exports[`MalcolmMiddlePanel renders alarmed correctly 1`] = `
         alarmSeverity={4}
       />
     </div>
+    <div
+      className="MiddlePanelContainer-paletteButton-5"
+      style={
+        Object {
+          "bottom": 12,
+          "right": 29,
+        }
+      }
+    >
+      <WithStyles(Button)
+        color="secondary"
+        onClick={[Function]}
+        variant="fab"
+      >
+        <pure(Add) />
+      </WithStyles(Button)>
+    </div>
   </div>
 </div>
 `;
@@ -109,6 +126,23 @@ exports[`MalcolmMiddlePanel renders errored correctly 1`] = `
       <WithTheme(AttributeAlarm)
         alarmSeverity={-1}
       />
+    </div>
+    <div
+      className="MiddlePanelContainer-paletteButton-5"
+      style={
+        Object {
+          "bottom": 12,
+          "right": 29,
+        }
+      }
+    >
+      <WithStyles(Button)
+        color="secondary"
+        onClick={[Function]}
+        variant="fab"
+      >
+        <pure(Add) />
+      </WithStyles(Button)>
     </div>
   </div>
 </div>
@@ -137,6 +171,23 @@ exports[`MalcolmMiddlePanel renders layout correctly 1`] = `
         alarmSeverity={-1}
       />
     </div>
+    <div
+      className="MiddlePanelContainer-paletteButton-5"
+      style={
+        Object {
+          "bottom": 12,
+          "right": 29,
+        }
+      }
+    >
+      <WithStyles(Button)
+        color="secondary"
+        onClick={[Function]}
+        variant="fab"
+      >
+        <pure(Add) />
+      </WithStyles(Button)>
+    </div>
   </div>
 </div>
 `;
@@ -164,6 +215,23 @@ exports[`MalcolmMiddlePanel renders pending correctly 1`] = `
         alarmSeverity={-1}
       />
     </div>
+    <div
+      className="MiddlePanelContainer-paletteButton-5"
+      style={
+        Object {
+          "bottom": 12,
+          "right": 29,
+        }
+      }
+    >
+      <WithStyles(Button)
+        color="secondary"
+        onClick={[Function]}
+        variant="fab"
+      >
+        <pure(Add) />
+      </WithStyles(Button)>
+    </div>
   </div>
 </div>
 `;
@@ -175,10 +243,10 @@ exports[`MalcolmMiddlePanel renders table correctly 1`] = `
   role="presentation"
 >
   <div
-    className="MiddlePanelContainer-plainBackground-6"
+    className="MiddlePanelContainer-plainBackground-7"
   >
     <div
-      className="MiddlePanelContainer-tableContainer-5"
+      className="MiddlePanelContainer-tableContainer-6"
       style={
         Object {
           "left": 365,

--- a/src/mainMalcolmView/mainMalcolmView.container.js
+++ b/src/mainMalcolmView/mainMalcolmView.container.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import DrawerContainer from '../drawerContainer/drawerContainer.component';
 import BlockDetails from '../blockDetails/blockDetails.component';
 import MiddlePanelContainer from './middlePanel.container';
+import Palette from '../layout/palette/palette.component';
 
 const blockDetailsUrl = (rootUrl, blockTitle) =>
   `${rootUrl}/details/${blockTitle}`;
@@ -15,6 +16,15 @@ const popOutFunction = (rootUrl, width, blockTitle) =>
     `width=${width},height=${window.innerHeight}`
   );
 
+const childPanelSelector = props => {
+  if (props.showPalette) {
+    return <Palette />;
+  } else if (props.showInfo) {
+    return <div>Info goes here</div>;
+  }
+  return <BlockDetails />;
+};
+
 const MainMalcolmView = props => (
   <div>
     <DrawerContainer
@@ -24,7 +34,7 @@ const MainMalcolmView = props => (
     >
       <BlockDetails parent />
       <MiddlePanelContainer />
-      <BlockDetails />
+      {childPanelSelector(props)}
     </DrawerContainer>
   </div>
 );
@@ -38,9 +48,21 @@ const mapStateToProps = state => {
     ? state.malcolm.blocks[state.malcolm.childBlock]
     : undefined;
 
+  const showPalette = state.malcolm.childBlock === '.palette';
+  const showInfo = state.malcolm.childBlock === '.info';
+
+  let childBlockTitle = childBlock ? childBlock.name : '';
+  if (showPalette) {
+    childBlockTitle = 'Palette';
+  } else if (showInfo) {
+    childBlockTitle = 'Info';
+  }
+
   return {
     parentBlockTitle: parentBlock ? parentBlock.name : '',
-    childBlockTitle: childBlock ? childBlock.name : '',
+    childBlockTitle,
+    showPalette,
+    showInfo,
   };
 };
 
@@ -49,6 +71,11 @@ const mapDispatchToProps = () => ({});
 MainMalcolmView.propTypes = {
   parentBlockTitle: PropTypes.string,
   childBlockTitle: PropTypes.string,
+};
+
+childPanelSelector.propTypes = {
+  showPalette: PropTypes.bool.isRequired,
+  showInfo: PropTypes.bool.isRequired,
 };
 
 MainMalcolmView.defaultProps = {

--- a/src/mainMalcolmView/mainMalcolmView.test.js
+++ b/src/mainMalcolmView/mainMalcolmView.test.js
@@ -5,13 +5,13 @@ import MainMalcolmView from './mainMalcolmView.container';
 
 describe('MainMalcolmView', () => {
   let shallow;
+  let state;
+  let mockStore;
 
   beforeEach(() => {
     shallow = createShallow({ dive: true });
-  });
 
-  it('renders correctly', () => {
-    const state = {
+    state = {
       malcolm: {
         parentBlock: 'test1',
         blocks: {
@@ -22,8 +22,22 @@ describe('MainMalcolmView', () => {
       },
     };
 
-    const mockStore = configureStore();
+    mockStore = configureStore();
+  });
 
+  it('renders correctly', () => {
+    const wrapper = shallow(<MainMalcolmView store={mockStore(state)} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders palette if child block is .palette', () => {
+    state.malcolm.childBlock = '.palette';
+    const wrapper = shallow(<MainMalcolmView store={mockStore(state)} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders info if child block is .info', () => {
+    state.malcolm.childBlock = '.info';
     const wrapper = shallow(<MainMalcolmView store={mockStore(state)} />);
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/mainMalcolmView/middlePanel.container.js
+++ b/src/mainMalcolmView/middlePanel.container.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
 import { connect } from 'react-redux';
 import Layout from '../layout/layout.component';
 import TableContainer from '../malcolmWidgets/table/table.container';
@@ -11,6 +13,7 @@ import AttributeAlarm, {
 import blockUtils from '../malcolm/blockUtils';
 
 import malcolmLogo from '../malcolm-logo.png';
+import navigationActions from '../malcolm/actions/navigation.actions';
 
 const divBackground = 'rgb(48, 48, 48)';
 
@@ -37,6 +40,9 @@ const styles = () => ({
   },
   alarmText: {
     marginRight: 5,
+  },
+  paletteButton: {
+    position: 'absolute',
   },
   tableContainer: {
     display: 'flex',
@@ -74,6 +80,18 @@ const findAttributeComponent = props => {
             style={{ left: props.openParent ? 360 + 29 : 29, bottom: 12 }}
           >
             <AttributeAlarm alarmSeverity={props.mainAttributeAlarmState} />
+          </div>
+          <div
+            className={props.classes.paletteButton}
+            style={{ right: props.openChild ? 360 + 29 : 29, bottom: 12 }}
+          >
+            <Button
+              variant="fab"
+              color="secondary"
+              onClick={() => props.openPalette()}
+            >
+              <AddIcon />
+            </Button>
           </div>
         </div>
       );
@@ -163,6 +181,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => ({
   resetSelection: () => resetSelection(dispatch),
+  openPalette: () => dispatch(navigationActions.navigateToPalette()),
 });
 
 findAttributeComponent.propTypes = {
@@ -178,6 +197,7 @@ findAttributeComponent.propTypes = {
     tableContainer: PropTypes.string,
     plainBackground: PropTypes.string,
   }).isRequired,
+  openPalette: PropTypes.func.isRequired,
 };
 
 MiddlePanelContainer.propTypes = {

--- a/src/malcolm/NavTypes.js
+++ b/src/malcolm/NavTypes.js
@@ -2,6 +2,7 @@ const NavTypes = {
   Block: 'block',
   Attribute: 'attribute',
   Info: 'info',
+  Palette: 'palette',
 };
 
 export default NavTypes;

--- a/src/malcolm/actions/navigation.actions.js
+++ b/src/malcolm/actions/navigation.actions.js
@@ -40,10 +40,31 @@ const navigateToAttribute = (blockMri, attributeName) => (
   }
 };
 
+const navigateToPalette = () => (dispatch, getState) => {
+  const state = getState().malcolm;
+  const { navigationLists } = state.navigation;
+
+  const lastAttributeNav = [...navigationLists]
+    .reverse()
+    .findIndex(nav => nav.navType === NavTypes.Attribute);
+  if (lastAttributeNav > -1) {
+    const newPath = `/gui/${navigationLists
+      .filter((nav, i) => i <= navigationLists.length - 1 - lastAttributeNav)
+      .map(nav => nav.path)
+      .join('/')}/.palette`;
+    dispatch(push(newPath));
+  }
+};
+
+const isChildPanelNavType = navType =>
+  navType === NavTypes.Block ||
+  navType === NavTypes.Info ||
+  navType === NavTypes.Palette;
+
 const closeChildPanel = () => (dispatch, getState) => {
   const state = getState().malcolm;
   const { navigationLists } = state.navigation;
-  if (navigationLists.slice(-1)[0].navType === NavTypes.Block) {
+  if (isChildPanelNavType(navigationLists.slice(-1)[0].navType)) {
     const newPath = `/gui/${navigationLists
       .slice(0, -1)
       .map(nav => nav.path)
@@ -57,7 +78,7 @@ const updateChildPanel = newChild => (dispatch, getState) => {
   const { navigationLists } = state.navigation;
 
   let newPath;
-  if (navigationLists.slice(-1)[0].navType === NavTypes.Block) {
+  if (isChildPanelNavType(navigationLists.slice(-1)[0].navType)) {
     newPath = `/gui/${navigationLists
       .slice(0, -1)
       .map(nav => nav.path)
@@ -73,6 +94,7 @@ const updateChildPanel = newChild => (dispatch, getState) => {
 export default {
   subscribeToNewBlocksInRoute,
   navigateToAttribute,
+  navigateToPalette,
   updateChildPanel,
   closeChildPanel,
 };

--- a/src/malcolm/actions/navigation.actions.test.js
+++ b/src/malcolm/actions/navigation.actions.test.js
@@ -2,36 +2,38 @@ import navigationActions from './navigation.actions';
 import NavTypes from '../NavTypes';
 import { MalcolmNewBlock, MalcolmSend } from '../malcolm.types';
 
+const buildNavState = () => ({
+  malcolm: {
+    blocks: {
+      PANDA: {},
+    },
+    navigation: {
+      navigationLists: [
+        {
+          path: 'PANDA',
+          navType: NavTypes.Block,
+          blockMri: 'PANDA',
+        },
+        {
+          path: 'layout',
+          navType: NavTypes.Attribute,
+        },
+        {
+          path: 'SEQ2',
+          navType: NavTypes.Block,
+          blockMri: 'PANDA:SEQ2',
+        },
+      ],
+    },
+  },
+});
+
 describe('subscribeToNewBlocksInRoute', () => {
   it('subscribes to new blocks', () => {
     const navAction = navigationActions.subscribeToNewBlocksInRoute();
 
     const dispatches = [];
-    const state = {
-      malcolm: {
-        blocks: {
-          PANDA: {},
-        },
-        navigation: {
-          navigationLists: [
-            {
-              path: 'PANDA',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA',
-            },
-            {
-              path: 'layout',
-              navType: NavTypes.Attribute,
-            },
-            {
-              path: 'SEQ2',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA:SEQ2',
-            },
-          ],
-        },
-      },
-    };
+    const state = buildNavState();
 
     navAction(action => dispatches.push(action), () => state);
 
@@ -48,28 +50,7 @@ describe('subscribeToNewBlocksInRoute', () => {
 describe('navigateToAttribute', () => {
   it('changes the url to look at the attribute', () => {
     const dispatches = [];
-    const state = {
-      malcolm: {
-        navigation: {
-          navigationLists: [
-            {
-              path: 'PANDA',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA',
-            },
-            {
-              path: 'layout',
-              navType: NavTypes.Attribute,
-            },
-            {
-              path: 'SEQ2',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA:SEQ2',
-            },
-          ],
-        },
-      },
-    };
+    const state = buildNavState();
 
     const navAction = navigationActions.navigateToAttribute(
       'PANDA:SEQ2',
@@ -86,33 +67,27 @@ describe('navigateToAttribute', () => {
   });
 });
 
+describe('navigateToPalette', () => {
+  it('changes the url to show the palette', () => {
+    const dispatches = [];
+    const state = buildNavState();
+
+    const navAction = navigationActions.navigateToPalette();
+
+    navAction(action => dispatches.push(action), () => state);
+
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0].type).toEqual('@@router/CALL_HISTORY_METHOD');
+    expect(dispatches[0].payload.args[0]).toEqual('/gui/PANDA/layout/.palette');
+  });
+});
+
 describe('updateChildPanel', () => {
   let state;
   let dispatches;
   beforeEach(() => {
     dispatches = [];
-    state = {
-      malcolm: {
-        navigation: {
-          navigationLists: [
-            {
-              path: 'PANDA',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA',
-            },
-            {
-              path: 'layout',
-              navType: NavTypes.Attribute,
-            },
-            {
-              path: 'SEQ2',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA:SEQ2',
-            },
-          ],
-        },
-      },
-    };
+    state = buildNavState();
   });
   it('updateChildPanel adds to the end of the route if it ends in layout', () => {
     state.malcolm.navigation.navigationLists.pop();
@@ -133,28 +108,7 @@ describe('closeChildPanel', () => {
   let dispatches;
   beforeEach(() => {
     dispatches = [];
-    state = {
-      malcolm: {
-        navigation: {
-          navigationLists: [
-            {
-              path: 'PANDA',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA',
-            },
-            {
-              path: 'layout',
-              navType: NavTypes.Attribute,
-            },
-            {
-              path: 'SEQ2',
-              navType: NavTypes.Block,
-              blockMri: 'PANDA:SEQ2',
-            },
-          ],
-        },
-      },
-    };
+    state = buildNavState();
   });
 
   it('closeChildPanel updates the route to remove the child', () => {

--- a/src/malcolm/reducer/navigation.reducer.js
+++ b/src/malcolm/reducer/navigation.reducer.js
@@ -83,6 +83,9 @@ function updateNavTypes(state) {
         if (nav.path === '.info') {
           nav.navType = NavTypes.Info;
           nav.label = 'Info';
+        } else if (nav.path === '.palette') {
+          nav.navType = NavTypes.Palette;
+          nav.label = 'Palette';
         } else if (isBlockMri(nav.path, state.blocks)) {
           nav.navType = NavTypes.Block;
           nav.blockMri = nav.path;
@@ -134,7 +137,10 @@ function updateNavTypes(state) {
 
   // find parentBlock
   const details = navigationLists.filter(
-    nav => nav.navType === NavTypes.Block || nav.navType === NavTypes.Info
+    nav =>
+      nav.navType === NavTypes.Block ||
+      nav.navType === NavTypes.Info ||
+      nav.navType === NavTypes.Palette
   );
   if (details.length === 1) {
     updatedState.parentBlock = details[0].path;

--- a/src/malcolm/reducer/navigation.reducer.test.js
+++ b/src/malcolm/reducer/navigation.reducer.test.js
@@ -94,6 +94,19 @@ describe('NavigationReducer.updateNavTypes', () => {
     expect(state.navigation.navigationLists[3].navType).toEqual(NavTypes.Info);
   });
 
+  it('updateNavTypes adds the nav type for palette', () => {
+    state.navigation.navigationLists = [
+      { path: 'PANDA' },
+      { path: 'layout' },
+      { path: '.palette' },
+    ];
+    state = NavigationReducer.updateNavTypes(state);
+
+    expect(state.navigation.navigationLists[2].navType).toEqual(
+      NavTypes.Palette
+    );
+  });
+
   it('updateNavTypes loads children for each nav element', () => {
     state = NavigationReducer.updateNavTypes(state);
 
@@ -128,6 +141,17 @@ describe('NavigationReducer.updateNavTypes', () => {
     expect(state.parentBlock).toEqual('PANDA:SEQ2');
     expect(state.mainAttribute).toEqual(undefined);
     expect(state.childBlock).toEqual('.info');
+  });
+
+  it('updateNavTypes sets parent/child blocks if palette', () => {
+    state.navigation.navigationLists = [
+      { path: 'PANDA' },
+      { path: 'layout' },
+      { path: '.palette' },
+    ];
+    state = NavigationReducer.updateNavTypes(state);
+
+    expect(state.childBlock).toEqual('.palette');
   });
 
   it('updateNavTypes sets main attribute', () => {


### PR DESCRIPTION
## Description

First part of the palette story to allow the `/layout/.palette` route to show a palette component in the child block panel.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Run the site and go to the layout, click on the palette button and see it appear in the right hand panel

## Agile board tracking

connect to #233