### PR TITLE
Feature/table row alarms #228

### DIFF
--- a/src/mainMalcolmView/__snapshots__/middlePanel.container.test.js.snap
+++ b/src/mainMalcolmView/__snapshots__/middlePanel.container.test.js.snap
@@ -192,9 +192,20 @@ exports[`MalcolmMiddlePanel renders table correctly 1`] = `
         blockName="test1"
         footerItems={
           Array [
-            <WithTheme(AttributeAlarm)
-              alarmSeverity={-1}
-          />,
+            <WithStyles(Tooltip)
+              id="1"
+              placement="right"
+              title={undefined}
+          >
+              <WithStyles(IconButton)
+                  className="MiddlePanelContainer-button-7"
+                  disableRipple={true}
+              >
+                  <WithTheme(AttributeAlarm)
+                      alarmSeverity={-1}
+                  />
+              </WithStyles(IconButton)>
+          </WithStyles(Tooltip)>,
           ]
         }
       />

--- a/src/mainMalcolmView/middlePanel.container.js
+++ b/src/mainMalcolmView/middlePanel.container.js
@@ -149,6 +149,10 @@ const mapStateToProps = state => {
 
   if (attribute && attribute.raw.alarm) {
     alarm = attribute.raw.alarm.severity;
+    alarm =
+      attribute.localState && attribute.localState.flags.table.dirty
+        ? AlarmStates.DIRTY
+        : alarm;
     alarm = attribute.calculated.errorState ? AlarmStates.MAJOR_ALARM : alarm;
     alarm = attribute.calculated.pending ? AlarmStates.PENDING : alarm;
   }

--- a/src/mainMalcolmView/middlePanel.container.js
+++ b/src/mainMalcolmView/middlePanel.container.js
@@ -162,11 +162,17 @@ const mapStateToProps = state => {
   let errorMessage;
   if (attribute && attribute.raw.alarm) {
     alarm = attribute.raw.alarm.severity;
+    alarm = attribute.calculated.errorState ? AlarmStates.MAJOR_ALARM : alarm;
     alarm =
       attribute.localState && attribute.localState.flags.table.dirty
         ? AlarmStates.DIRTY
         : alarm;
-    alarm = attribute.calculated.errorState ? AlarmStates.MAJOR_ALARM : alarm;
+    alarm =
+      attribute.localState &&
+      attribute.localState.flags.table.dirty &&
+      attribute.calculated.errorState
+        ? AlarmStates.DIRTYANDERROR
+        : alarm;
     alarm = attribute.calculated.pending ? AlarmStates.PENDING : alarm;
     errorMessage = attribute.calculated.errorState
       ? attribute.calculated.errorMessage

--- a/src/mainMalcolmView/middlePanel.container.js
+++ b/src/mainMalcolmView/middlePanel.container.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { connect } from 'react-redux';
+import Tooltip from '@material-ui/core/Tooltip';
+import IconButton from '@material-ui/core/IconButton';
 import Layout from '../layout/layout.component';
 import TableContainer from '../malcolmWidgets/table/table.container';
 import { malcolmSelectBlock } from '../malcolm/malcolmActionCreators';
@@ -53,6 +55,13 @@ const styles = () => ({
     backgroundColor: divBackground,
     align: 'center',
   },
+  button: {
+    width: '22px',
+    height: '22px',
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
+  },
 });
 
 const getWidgetType = tags => {
@@ -94,9 +103,13 @@ const findAttributeComponent = props => {
               attributeName={props.mainAttribute}
               blockName={props.parentBlock}
               footerItems={[
-                <AttributeAlarm
-                  alarmSeverity={props.mainAttributeAlarmState}
-                />,
+                <Tooltip id="1" title={props.errorMessage} placement="right">
+                  <IconButton className={props.classes.button} disableRipple>
+                    <AttributeAlarm
+                      alarmSeverity={props.mainAttributeAlarmState}
+                    />
+                  </IconButton>
+                </Tooltip>,
               ]}
             />
           </div>
@@ -146,7 +159,7 @@ const mapStateToProps = state => {
   );
 
   let alarm = AlarmStates.PENDING;
-
+  let errorMessage;
   if (attribute && attribute.raw.alarm) {
     alarm = attribute.raw.alarm.severity;
     alarm =
@@ -155,8 +168,12 @@ const mapStateToProps = state => {
         : alarm;
     alarm = attribute.calculated.errorState ? AlarmStates.MAJOR_ALARM : alarm;
     alarm = attribute.calculated.pending ? AlarmStates.PENDING : alarm;
+    errorMessage = attribute.calculated.errorState
+      ? attribute.calculated.errorMessage
+      : '';
   }
   return {
+    errorMessage,
     parentBlock: state.malcolm.parentBlock,
     mainAttribute: state.malcolm.mainAttribute,
     mainAttributeAlarmState: alarm,
@@ -176,7 +193,9 @@ findAttributeComponent.propTypes = {
   mainAttributeAlarmState: PropTypes.number.isRequired,
   openParent: PropTypes.bool.isRequired,
   openChild: PropTypes.bool.isRequired,
+  errorMessage: PropTypes.string.isRequired,
   classes: PropTypes.shape({
+    button: PropTypes.string,
     layoutArea: PropTypes.string,
     alarm: PropTypes.string,
     alarmText: PropTypes.string,

--- a/src/malcolm/reducer/attribute.reducer.js
+++ b/src/malcolm/reducer/attribute.reducer.js
@@ -9,7 +9,7 @@ import {
   MalcolmAttributeData,
   MalcolmMainAttributeUpdate,
 } from '../malcolm.types';
-import { rowIsDifferent } from './table.reducer';
+import { shouldClearDirtyFlag } from './table.reducer';
 
 export const updateAttributeChildren = attribute => {
   const updatedAttribute = { ...attribute };
@@ -201,17 +201,7 @@ export function updateAttribute(oldState, payload) {
 
         if (attribute.localState !== undefined) {
           const labels = Object.keys(attribute.raw.meta.elements);
-          if (attribute.localState.flags.table.dirty) {
-            attribute.localState.flags.rows.forEach((row, index) => {
-              attribute.localState.flags.rows[index] = {
-                ...row,
-                _isChanged: rowIsDifferent(attribute, index),
-              };
-            });
-            attribute.localState.flags.table.dirty = attribute.localState.flags.rows.some(
-              row => row._dirty || row._isChanged
-            );
-          }
+          attribute = shouldClearDirtyFlag(attribute);
           if (!attribute.localState.flags.table.dirty) {
             attribute.localState = {
               value: attribute.raw.value[labels[0]].map((value, row) => {

--- a/src/malcolm/reducer/attribute.reducer.js
+++ b/src/malcolm/reducer/attribute.reducer.js
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle: 0 */
 import navigationReducer, {
   processNavigationLists,
 } from './navigation.reducer';
@@ -200,6 +201,17 @@ export function updateAttribute(oldState, payload) {
 
         if (attribute.localState !== undefined) {
           const labels = Object.keys(attribute.raw.meta.elements);
+          if (attribute.localState.flags.table.dirty) {
+            attribute.localState.flags.rows.forEach((row, index) => {
+              attribute.localState.flags.rows[index] = {
+                ...row,
+                _isChanged: rowIsDifferent(attribute, index),
+              };
+            });
+            attribute.localState.flags.table.dirty = attribute.localState.flags.rows.some(
+              row => row._dirty || row._isChanged
+            );
+          }
           if (!attribute.localState.flags.table.dirty) {
             attribute.localState = {
               value: attribute.raw.value[labels[0]].map((value, row) => {
@@ -220,15 +232,7 @@ export function updateAttribute(oldState, payload) {
               },
             };
           } else {
-            attributes[
-              matchingAttributeIndex
-            ].localState.flags.table.fresh = false;
-            attribute.localState.flags.rows.forEach((row, index) => {
-              attribute.localState.flags.rows[index] = {
-                ...row,
-                _isChanged: rowIsDifferent(attribute, index),
-              };
-            });
+            attribute.localState.flags.table.fresh = false;
           }
         }
         attributes[matchingAttributeIndex] = attribute;

--- a/src/malcolm/reducer/table.reducer.js
+++ b/src/malcolm/reducer/table.reducer.js
@@ -27,6 +27,7 @@ export const shouldClearDirtyFlag = inputAttribute => {
     attribute.localState.flags.table.dirty = attribute.localState.flags.rows.some(
       row => row._dirty || row._isChanged
     );
+    attribute.calculated.dirty = attribute.localState.flags.table.dirty;
   }
   return attribute;
 };
@@ -66,6 +67,7 @@ export const copyAttributeValue = (state, payload) => {
         },
       },
     };
+    attribute.calculated.dirty = false;
     attributes[matchingAttributeIndex] = attribute;
     blocks[blockName] = { ...state.blocks[blockName], attributes };
   }
@@ -135,6 +137,9 @@ const setTableFlag = (state, payload) => {
       ...payload.flags,
     };
     if (payload.flagType === 'selected') {
+      attribute.localState.flags.rows.forEach((row, index) => {
+        attribute.localState.flags.rows[index].selected = index === payload.row;
+      });
       attribute.localState.flags.table.selectedRow = payload.row;
     } else {
       attribute.localState.flags.table[
@@ -144,6 +149,9 @@ const setTableFlag = (state, payload) => {
           row[`_${payload.flagType}`] ||
           (payload.flagType === 'dirty' && row._isChanged)
       );
+      if (payload.flagType === 'dirty') {
+        attribute.calculated.dirty = attribute.localState.flags.table.dirty;
+      }
     }
     attributes[matchingAttributeIndex] = attribute;
     blocks[blockName] = { ...state.blocks[blockName], attributes };

--- a/src/malcolm/reducer/table.reducer.js
+++ b/src/malcolm/reducer/table.reducer.js
@@ -28,7 +28,7 @@ export const copyAttributeValue = (state, payload) => {
       value: JSON.parse(JSON.stringify(attribute.raw.value)),
       labels: Object.keys(attribute.raw.meta.elements),
       flags: {
-        rows: [],
+        rows: Object.keys(attribute.raw.meta.elements).map(() => ({})),
         table: {
           fresh: true,
           timeStamp: JSON.parse(JSON.stringify(attribute.raw.timeStamp)),

--- a/src/malcolm/reducer/table.reducer.js
+++ b/src/malcolm/reducer/table.reducer.js
@@ -30,6 +30,7 @@ export const copyAttributeValue = (state, payload) => {
       flags: {
         rows: Object.keys(attribute.raw.meta.elements).map(() => ({})),
         table: {
+          dirty: false,
           fresh: true,
           timeStamp: JSON.parse(JSON.stringify(attribute.raw.timeStamp)),
         },

--- a/src/malcolm/reducer/table.reducer.test.js
+++ b/src/malcolm/reducer/table.reducer.test.js
@@ -9,13 +9,13 @@ import { getDefaultFromType } from '../../malcolmWidgets/attributeDetails/attrib
 import { harderAttribute } from '../../malcolmWidgets/table/table.stories';
 
 const addRow = (table, columns, row) => {
-  columns.forEach(label =>
-    table[label].splice(
-      row,
-      0,
-      getDefaultFromType(harderAttribute.raw.meta.elements[label])
-    )
-  );
+  const defaultRow = {};
+  columns.forEach(label => {
+    defaultRow[label] = getDefaultFromType(
+      harderAttribute.raw.meta.elements[label]
+    );
+  });
+  table.splice(row, 0, defaultRow);
   return table;
 };
 
@@ -29,23 +29,36 @@ describe('Table reducer', () => {
     },
   };
 
+  const rowValues = harderAttribute.raw.value[
+    Object.keys(harderAttribute.raw.meta.elements)[0]
+  ].map((val, row) => {
+    const rowData = {};
+    Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+      rowData[label] = harderAttribute.raw.value[label][row];
+    });
+    return rowData;
+  });
+
   const expectedCopy = {
-    value: JSON.parse(JSON.stringify(harderAttribute.raw.value)),
+    value: JSON.parse(JSON.stringify(rowValues)),
     meta: JSON.parse(JSON.stringify(harderAttribute.raw.meta)),
     labels: Object.keys(harderAttribute.raw.meta.elements),
     flags: {
-      rows: [],
+      rows: harderAttribute.raw.value[
+        Object.keys(harderAttribute.raw.meta.elements)[0]
+      ].map(() => ({})),
       table: {
+        dirty: false,
         fresh: true,
         timeStamp: JSON.parse(JSON.stringify(harderAttribute.raw.timeStamp)),
       },
     },
   };
 
-  const expectedValue = JSON.parse(JSON.stringify(harderAttribute.raw.value));
-  expectedValue.x[1] = 10;
-  expectedValue.y[1] = 15;
-  expectedValue.visible[1] = true;
+  const expectedValue = JSON.parse(JSON.stringify(rowValues));
+  expectedValue[1].x = 10;
+  expectedValue[1].y = 15;
+  expectedValue[1].visible = true;
 
   let state;
 
@@ -133,7 +146,15 @@ describe('Table reducer', () => {
       payload,
     };
     testState = TableReducer(testState, action);
-    let splicedValue = JSON.parse(JSON.stringify(harderAttribute.raw.value));
+    let splicedValue = harderAttribute.raw.value[
+      Object.keys(harderAttribute.raw.meta.elements)[0]
+    ].map((val, row) => {
+      const rowData = {};
+      Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+        rowData[label] = harderAttribute.raw.value[label][row];
+      });
+      return rowData;
+    });
     splicedValue = addRow(splicedValue, labels, 4);
     expect(testState.blocks.block1.attributes[0].localState.value).toEqual(
       splicedValue
@@ -151,7 +172,15 @@ describe('Table reducer', () => {
       payload,
     };
     testState = TableReducer(testState, action);
-    let splicedValue = JSON.parse(JSON.stringify(harderAttribute.raw.value));
+    let splicedValue = harderAttribute.raw.value[
+      Object.keys(harderAttribute.raw.meta.elements)[0]
+    ].map((val, row) => {
+      const rowData = {};
+      Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+        rowData[label] = harderAttribute.raw.value[label][row];
+      });
+      return rowData;
+    });
     splicedValue = addRow(splicedValue, labels, 1);
     expect(testState.blocks.block1.attributes[0].localState.value).toEqual(
       splicedValue
@@ -163,7 +192,15 @@ describe('Table reducer', () => {
     testState = TableReducer(state, copyAction);
 
     expect(testState.blocks.block1.attributes[0].localState.value).toEqual(
-      harderAttribute.raw.value
+      harderAttribute.raw.value[
+        Object.keys(harderAttribute.raw.meta.elements)[0]
+      ].map((val, row) => {
+        const rowData = {};
+        Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+          rowData[label] = harderAttribute.raw.value[label][row];
+        });
+        return rowData;
+      })
     );
   });
 

--- a/src/malcolm/reducer/table.reducer.test.js
+++ b/src/malcolm/reducer/table.reducer.test.js
@@ -230,6 +230,34 @@ describe('Table reducer', () => {
     ).toEqual(1);
   });
 
+  it('set flag deselects all other rows', () => {
+    testState.blocks.block1.attributes[0].localState.flags.table.selectedRow = 1;
+    testState.blocks.block1.attributes[0].localState.flags.rows[1] = {
+      selected: true,
+    };
+    const payload = {
+      path: ['block1', 'layout'],
+      row: 2,
+      flagType: 'selected',
+      flags: { selected: true },
+    };
+    const flagAction = {
+      type: MalcolmTableFlag,
+      payload,
+    };
+    testState = TableReducer(testState, flagAction);
+
+    expect(
+      testState.blocks.block1.attributes[0].localState.flags.rows[1]
+    ).toEqual({ selected: false });
+    expect(
+      testState.blocks.block1.attributes[0].localState.flags.rows[2]
+    ).toEqual({ selected: true });
+    expect(
+      testState.blocks.block1.attributes[0].localState.flags.table.selectedRow
+    ).toEqual(2);
+  });
+
   it('set flag sets table as dirty if a dirty flag is set to true', () => {
     const payload = {
       path: ['block1', 'layout'],

--- a/src/malcolm/reducer/table.reducer.test.js
+++ b/src/malcolm/reducer/table.reducer.test.js
@@ -1,12 +1,15 @@
 /* eslint no-underscore-dangle: 0 */
-import TableReducer from './table.reducer';
+import TableReducer, { shouldClearDirtyFlag } from './table.reducer';
 import {
   MalcolmTableUpdate,
   MalcolmLocalCopy,
   MalcolmTableFlag,
 } from '../malcolm.types';
 import { getDefaultFromType } from '../../malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component';
-import { harderAttribute } from '../../malcolmWidgets/table/table.stories';
+import {
+  harderAttribute,
+  expectedCopy,
+} from '../../malcolmWidgets/table/table.stories';
 
 const addRow = (table, columns, row) => {
   const defaultRow = {};
@@ -19,6 +22,16 @@ const addRow = (table, columns, row) => {
   return table;
 };
 
+const rowValues = harderAttribute.raw.value[
+  Object.keys(harderAttribute.raw.meta.elements)[0]
+].map((val, row) => {
+  const rowData = {};
+  Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+    rowData[label] = harderAttribute.raw.value[label][row];
+  });
+  return rowData;
+});
+
 describe('Table reducer', () => {
   let testState;
   const labels = Object.keys(harderAttribute.raw.meta.elements);
@@ -26,32 +39,6 @@ describe('Table reducer', () => {
     type: MalcolmLocalCopy,
     payload: {
       path: ['block1', 'layout'],
-    },
-  };
-
-  const rowValues = harderAttribute.raw.value[
-    Object.keys(harderAttribute.raw.meta.elements)[0]
-  ].map((val, row) => {
-    const rowData = {};
-    Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
-      rowData[label] = harderAttribute.raw.value[label][row];
-    });
-    return rowData;
-  });
-
-  const expectedCopy = {
-    value: JSON.parse(JSON.stringify(rowValues)),
-    meta: JSON.parse(JSON.stringify(harderAttribute.raw.meta)),
-    labels: Object.keys(harderAttribute.raw.meta.elements),
-    flags: {
-      rows: harderAttribute.raw.value[
-        Object.keys(harderAttribute.raw.meta.elements)[0]
-      ].map(() => ({})),
-      table: {
-        dirty: false,
-        fresh: true,
-        timeStamp: JSON.parse(JSON.stringify(harderAttribute.raw.timeStamp)),
-      },
     },
   };
 
@@ -222,6 +209,27 @@ describe('Table reducer', () => {
     ).toEqual({ testFlag: true });
   });
 
+  it('set flag sets row selected on table', () => {
+    const payload = {
+      path: ['block1', 'layout'],
+      row: 1,
+      flagType: 'selected',
+      flags: { selected: true },
+    };
+    const flagAction = {
+      type: MalcolmTableFlag,
+      payload,
+    };
+    testState = TableReducer(testState, flagAction);
+
+    expect(
+      testState.blocks.block1.attributes[0].localState.flags.rows[1]
+    ).toEqual({ selected: true });
+    expect(
+      testState.blocks.block1.attributes[0].localState.flags.table.selectedRow
+    ).toEqual(1);
+  });
+
   it('set flag sets table as dirty if a dirty flag is set to true', () => {
     const payload = {
       path: ['block1', 'layout'],
@@ -280,5 +288,32 @@ describe('Table reducer', () => {
     expect(
       testState.blocks.block1.attributes[0].localState.flags.table.dirty
     ).toBeTruthy();
+  });
+
+  it('should clear dirty clears dirty does nothing if dirty flag not true', () => {
+    let testAttr = shouldClearDirtyFlag(testState.blocks.block1.attributes[0]);
+    expect(testAttr.localState.flags.table.dirty).toBeFalsy();
+    testState.blocks.block1.attributes[0].raw.value.visible[0] = !testState
+      .blocks.block1.attributes[0].raw.value.visible[0];
+    testAttr = shouldClearDirtyFlag(testState.blocks.block1.attributes[0]);
+    expect(testAttr.localState.flags.table.dirty).toBeFalsy();
+  });
+
+  it('should clear dirty clears dirty if all rows match', () => {
+    testState.blocks.block1.attributes[0].localState.flags.table.dirty = true;
+    const testAttr = shouldClearDirtyFlag(
+      testState.blocks.block1.attributes[0]
+    );
+    expect(testAttr.localState.flags.table.dirty).toBeFalsy();
+  });
+
+  it('should clear dirty doesnt clear dirty if not all rows match', () => {
+    testState.blocks.block1.attributes[0].localState.flags.table.dirty = true;
+    testState.blocks.block1.attributes[0].raw.value.visible[0] = !testState
+      .blocks.block1.attributes[0].raw.value.visible[0];
+    const testAttr = shouldClearDirtyFlag(
+      testState.blocks.block1.attributes[0]
+    );
+    expect(testAttr.localState.flags.table.dirty).toBeTruthy();
   });
 });

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/EditError.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/EditError.component.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const EditError = props => (
+  <div>
+    <svg
+      width="26"
+      height="26"
+      version="1.1"
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="m24 4c-11.04 0-20 8.95-20 20s8.96 20 20 20 20-8.95 20-20-8.96-20-20-20zm7.5527 8c0.34172 0 0.68332 0.13059 0.94336 0.39062l3.1133 3.1133c0.52007 0.52007 0.52007 1.3666 0 1.8867l-2.4395 2.4414-5.002-5.002 2.4414-2.4395c0.26004-0.26004 0.60164-0.39062 0.94336-0.39062zm-4.7969 4.2441 5 5-14.756 14.756h-5v-5l14.756-14.756z"
+        fill={props.nativeColor}
+      />
+    </svg>
+  </div>
+);
+
+EditError.propTypes = {
+  nativeColor: PropTypes.string.isRequired,
+};
+
+export default EditError;

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/__snapshots__/attributeAlarm.test.js.snap
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/__snapshots__/attributeAlarm.test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`AttributeAlarm renders blank if no alarm severity specified 1`] = `<div />`;
 
+exports[`AttributeAlarm renders dirty & error correctly 1`] = `
+<EditError
+  nativeColor="#f44336"
+/>
+`;
+
 exports[`AttributeAlarm renders dirty correctly 1`] = `
 <pure(Edit)
   nativeColor="#7986cb"

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
@@ -9,6 +9,7 @@ import {
 } from '@material-ui/icons';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { withTheme } from '@material-ui/core/styles/index';
+import EditError from './EditError.component';
 
 export const AlarmStates = {
   NO_ALARM: 0,
@@ -18,6 +19,7 @@ export const AlarmStates = {
   UNDEFINED_ALARM: 4,
   PENDING: -1,
   DIRTY: -2,
+  DIRTYANDERROR: -3,
 };
 
 const AttributeAlarm = props => {
@@ -47,6 +49,9 @@ const AttributeAlarm = props => {
 
     case AlarmStates.DIRTY:
       return <Edit nativeColor={props.theme.palette.primary.light} />;
+
+    case AlarmStates.DIRTYANDERROR:
+      return <EditError nativeColor={props.theme.palette.error.main} />;
 
     default:
       return <div />;

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.test.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.test.js
@@ -61,6 +61,13 @@ describe('AttributeAlarm', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('renders dirty & error correctly', () => {
+    const wrapper = shallow(
+      <AttributeAlarm alarmSeverity={AlarmStates.DIRTYANDERROR} />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders blank if no alarm severity specified', () => {
     const wrapper = shallow(<AttributeAlarm />);
     expect(wrapper).toMatchSnapshot();

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -48,10 +48,14 @@ const AttributeDetails = props => {
   }
   if (widgetTagIndex !== null) {
     let alarm = props.attribute.raw.alarm.severity;
-    alarm = props.attribute.calculated.dirty ? AlarmStates.DIRTY : alarm;
     alarm = props.attribute.calculated.errorState
       ? AlarmStates.MAJOR_ALARM
       : alarm;
+    alarm = props.attribute.calculated.dirty ? AlarmStates.DIRTY : alarm;
+    alarm =
+      props.attribute.calculated.dirty && props.attribute.calculated.errorState
+        ? AlarmStates.DIRTYANDERROR
+        : alarm;
     alarm = props.attribute.calculated.pending ? AlarmStates.PENDING : alarm;
     const message = props.attribute.calculated.errorMessage
       ? props.attribute.calculated.errorMessage

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.stories.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.stories.js
@@ -67,4 +67,8 @@ storiesOf('Details/Attribute Details', module)
     'pending',
     withInfo(generateInfo('PENDING'))(() => generateComponent(-1))
   )
-  .add('dirty', withInfo(generateInfo('DIRTY'))(() => generateComponent(-2)));
+  .add('dirty', withInfo(generateInfo('DIRTY'))(() => generateComponent(-2)))
+  .add(
+    'dirty & error',
+    withInfo(generateInfo('DIRTY & ERROR'))(() => generateComponent(-3))
+  );

--- a/src/malcolmWidgets/table/__snapshots__/table.component.test.js.snap
+++ b/src/malcolmWidgets/table/__snapshots__/table.component.test.js.snap
@@ -11,6 +11,11 @@ exports[`WidgetTable renders correctly 1`] = `
       >
         <WithStyles(TableCell)
           className="WidgetTable-textHeadings-8"
+          key="-1"
+          padding="none"
+        />
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
           key="0"
           padding="none"
         >
@@ -59,7 +64,22 @@ exports[`WidgetTable renders correctly 1`] = `
           key="0"
         >
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
             key="0,0"
             padding="none"
           >
@@ -89,7 +109,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="0,1"
             padding="none"
           >
@@ -119,7 +139,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="0,2"
             padding="none"
           >
@@ -150,7 +170,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="0,3"
             padding="none"
           >
@@ -181,7 +201,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="0,4"
             padding="none"
           >
@@ -216,7 +236,22 @@ exports[`WidgetTable renders correctly 1`] = `
           key="1"
         >
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
             key="1,0"
             padding="none"
           >
@@ -246,7 +281,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="1,1"
             padding="none"
           >
@@ -276,7 +311,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="1,2"
             padding="none"
           >
@@ -307,7 +342,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="1,3"
             padding="none"
           >
@@ -338,7 +373,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="1,4"
             padding="none"
           >
@@ -373,7 +408,22 @@ exports[`WidgetTable renders correctly 1`] = `
           key="2"
         >
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
             key="2,0"
             padding="none"
           >
@@ -403,7 +453,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="2,1"
             padding="none"
           >
@@ -433,7 +483,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="2,2"
             padding="none"
           >
@@ -464,7 +514,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="2,3"
             padding="none"
           >
@@ -495,7 +545,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="2,4"
             padding="none"
           >
@@ -530,7 +580,22 @@ exports[`WidgetTable renders correctly 1`] = `
           key="3"
         >
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
             key="3,0"
             padding="none"
           >
@@ -560,7 +625,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="3,1"
             padding="none"
           >
@@ -590,7 +655,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="3,2"
             padding="none"
           >
@@ -621,7 +686,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="3,3"
             padding="none"
           >
@@ -652,7 +717,7 @@ exports[`WidgetTable renders correctly 1`] = `
             />
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
-            className="WidgetTable-textBody-9"
+            className="WidgetTable-textBody-10"
             key="3,4"
             padding="none"
           >
@@ -698,7 +763,14 @@ exports[`WidgetTable renders correctly 1`] = `
             <WithStyles(IconButton)
               onClick={[Function]}
             >
-              <pure(Add) />
+              <pure(Add)
+                style={
+                  Object {
+                    "height": "30px",
+                    "width": "30px",
+                  }
+                }
+              />
             </WithStyles(IconButton)>
           </WithStyles(TableCell)>
         </WithStyles(TableRow)>

--- a/src/malcolmWidgets/table/__snapshots__/table.component.test.js.snap
+++ b/src/malcolmWidgets/table/__snapshots__/table.component.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WidgetTable renders correctly 1`] = `
+exports[`WidgetTable renders correctly with no selected row 1`] = `
 <div>
   <WithStyles(Table)
     className="WidgetTable-headerLayoutNoScroll-3"
@@ -374,6 +374,795 @@ exports[`WidgetTable renders correctly 1`] = `
           </WithStyles(TableCell)>
           <WithStyles(TableCell)
             className="WidgetTable-textBody-10"
+            key="1,4"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Whether child blocks are visible",
+                  "label": "Visible",
+                  "tags": Array [
+                    "widget:checkbox",
+                  ],
+                  "typeid": "malcolm:core/BooleanArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:checkbox"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 4,
+                  "label": "visible",
+                  "row": 1,
+                }
+              }
+              setFlag={[Function]}
+              value={false}
+            />
+          </WithStyles(TableCell)>
+        </WithStyles(TableRow)>
+        <WithStyles(TableRow)
+          className="WidgetTable-rowFormat-6"
+          key="2"
+        >
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="2,0"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Names of the layout parts",
+                  "label": "Name",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 0,
+                  "label": "name",
+                  "row": 2,
+                }
+              }
+              setFlag={[Function]}
+              value="INENC1"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="2,1"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Malcolm full names of child blocks",
+                  "label": "MRI",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 1,
+                  "label": "mri",
+                  "row": 2,
+                }
+              }
+              setFlag={[Function]}
+              value="PANDA:INENC1"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="2,2"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "X Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "x",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 2,
+                  "label": "x",
+                  "row": 2,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="2,3"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Y Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "y",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 3,
+                  "label": "y",
+                  "row": 2,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="2,4"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Whether child blocks are visible",
+                  "label": "Visible",
+                  "tags": Array [
+                    "widget:checkbox",
+                  ],
+                  "typeid": "malcolm:core/BooleanArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:checkbox"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 4,
+                  "label": "visible",
+                  "row": 2,
+                }
+              }
+              setFlag={[Function]}
+              value={false}
+            />
+          </WithStyles(TableCell)>
+        </WithStyles(TableRow)>
+        <WithStyles(TableRow)
+          className="WidgetTable-rowFormat-6"
+          key="3"
+        >
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="3,0"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Names of the layout parts",
+                  "label": "Name",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 0,
+                  "label": "name",
+                  "row": 3,
+                }
+              }
+              setFlag={[Function]}
+              value="INENC2"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="3,1"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Malcolm full names of child blocks",
+                  "label": "MRI",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 1,
+                  "label": "mri",
+                  "row": 3,
+                }
+              }
+              setFlag={[Function]}
+              value="PANDA:INENC2"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="3,2"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "X Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "x",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 2,
+                  "label": "x",
+                  "row": 3,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="3,3"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Y Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "y",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 3,
+                  "label": "y",
+                  "row": 3,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="3,4"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Whether child blocks are visible",
+                  "label": "Visible",
+                  "tags": Array [
+                    "widget:checkbox",
+                  ],
+                  "typeid": "malcolm:core/BooleanArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:checkbox"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 4,
+                  "label": "visible",
+                  "row": 3,
+                }
+              }
+              setFlag={[Function]}
+              value={false}
+            />
+          </WithStyles(TableCell)>
+        </WithStyles(TableRow)>
+      </WithStyles(TableBody)>
+    </WithStyles(Table)>
+    <WithStyles(Table)>
+      <WithStyles(TableFooter)>
+        <WithStyles(TableRow)
+          className="WidgetTable-rowFormat-6"
+          key="4"
+        >
+          <WithStyles(TableCell)
+            className="WidgetTable-incompleteRowFormat-7"
+            key="4,0"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              onClick={[Function]}
+            >
+              <pure(Add)
+                style={
+                  Object {
+                    "height": "30px",
+                    "width": "30px",
+                  }
+                }
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+        </WithStyles(TableRow)>
+      </WithStyles(TableFooter)>
+    </WithStyles(Table)>
+  </div>
+  <WithStyles(Table)
+    className="WidgetTable-footerLayout-2"
+  >
+    <WithStyles(TableFooter)>
+      <WithStyles(TableRow)
+        className="WidgetTable-rowFormat-6"
+      />
+    </WithStyles(TableFooter)>
+  </WithStyles(Table)>
+</div>
+`;
+
+exports[`WidgetTable renders correctly with selected row 1`] = `
+<div>
+  <WithStyles(Table)
+    className="WidgetTable-headerLayoutNoScroll-3"
+  >
+    <WithStyles(TableHead)>
+      <WithStyles(TableRow)
+        className="WidgetTable-rowFormat-6"
+      >
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
+          key="-1"
+          padding="none"
+        />
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
+          key="0"
+          padding="none"
+        >
+          Name
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
+          key="1"
+          padding="none"
+        >
+          MRI
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
+          key="2"
+          padding="none"
+        >
+          x
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
+          key="3"
+          padding="none"
+        >
+          y
+        </WithStyles(TableCell)>
+        <WithStyles(TableCell)
+          className="WidgetTable-textHeadings-8"
+          key="4"
+          padding="none"
+        >
+          Visible
+        </WithStyles(TableCell)>
+      </WithStyles(TableRow)>
+    </WithStyles(TableHead)>
+  </WithStyles(Table)>
+  <div
+    className="WidgetTable-tableBody-5"
+  >
+    <WithStyles(Table)
+      className="WidgetTable-tableLayout-4"
+    >
+      <WithStyles(TableBody)>
+        <WithStyles(TableRow)
+          className="WidgetTable-rowFormat-6"
+          key="0"
+        >
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="0,0"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Names of the layout parts",
+                  "label": "Name",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 0,
+                  "label": "name",
+                  "row": 0,
+                }
+              }
+              setFlag={[Function]}
+              value="TTLIN1"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="0,1"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Malcolm full names of child blocks",
+                  "label": "MRI",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 1,
+                  "label": "mri",
+                  "row": 0,
+                }
+              }
+              setFlag={[Function]}
+              value="PANDA:TTLIN1"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="0,2"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "X Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "x",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 2,
+                  "label": "x",
+                  "row": 0,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="0,3"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Y Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "y",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 3,
+                  "label": "y",
+                  "row": 0,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-textBody-10"
+            key="0,4"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Whether child blocks are visible",
+                  "label": "Visible",
+                  "tags": Array [
+                    "widget:checkbox",
+                  ],
+                  "typeid": "malcolm:core/BooleanArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:checkbox"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 4,
+                  "label": "visible",
+                  "row": 0,
+                }
+              }
+              setFlag={[Function]}
+              value={false}
+            />
+          </WithStyles(TableCell)>
+        </WithStyles(TableRow)>
+        <WithStyles(TableRow)
+          className="WidgetTable-rowFormat-6"
+          key="1"
+        >
+          <WithStyles(TableCell)
+            className="WidgetTable-blankCell-9"
+            key="-1"
+            padding="none"
+          >
+            <WithStyles(IconButton)
+              className="WidgetTable-button-11"
+              disableRipple={true}
+              onClick={[Function]}
+            >
+              <WithTheme(AttributeAlarm)
+                alarmSeverity={0}
+              />
+            </WithStyles(IconButton)>
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-blankCell-9"
+            key="1,0"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Names of the layout parts",
+                  "label": "Name",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 0,
+                  "label": "name",
+                  "row": 1,
+                }
+              }
+              setFlag={[Function]}
+              value="TTLIN2"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-blankCell-9"
+            key="1,1"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Malcolm full names of child blocks",
+                  "label": "MRI",
+                  "tags": Array [
+                    "widget:textupdate",
+                  ],
+                  "typeid": "malcolm:core/StringArrayMeta:1.0",
+                  "writeable": false,
+                }
+              }
+              columnWidgetTag="widget:textupdate"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 1,
+                  "label": "mri",
+                  "row": 1,
+                }
+              }
+              setFlag={[Function]}
+              value="PANDA:TTLIN2"
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-blankCell-9"
+            key="1,2"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "X Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "x",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 2,
+                  "label": "x",
+                  "row": 1,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-blankCell-9"
+            key="1,3"
+            padding="none"
+          >
+            <WithTheme(TableWidgetSelector)
+              columnMeta={
+                Object {
+                  "description": "Y Coordinates of child blocks",
+                  "dtype": "float64",
+                  "label": "y",
+                  "tags": Array [
+                    "widget:textinput",
+                  ],
+                  "typeid": "malcolm:core/NumberArrayMeta:1.0",
+                  "writeable": true,
+                }
+              }
+              columnWidgetTag="widget:textinput"
+              rowChangeHandler={[Function]}
+              rowPath={
+                Object {
+                  "column": 3,
+                  "label": "y",
+                  "row": 1,
+                }
+              }
+              setFlag={[Function]}
+              value={0}
+            />
+          </WithStyles(TableCell)>
+          <WithStyles(TableCell)
+            className="WidgetTable-blankCell-9"
             key="1,4"
             padding="none"
           >

--- a/src/malcolmWidgets/table/__snapshots__/table.container.test.js.snap
+++ b/src/malcolmWidgets/table/__snapshots__/table.container.test.js.snap
@@ -14,8 +14,14 @@ exports[`Table container renders correctly 1`] = `
       },
       "localState": Object {
         "flags": Object {
-          "rows": Array [],
+          "rows": Array [
+            Object {},
+            Object {},
+            Object {},
+            Object {},
+          ],
           "table": Object {
+            "dirty": false,
             "fresh": true,
             "timeStamp": Object {
               "nanoseconds": 0,
@@ -255,8 +261,14 @@ exports[`Table container renders correctly 1`] = `
   localState={
     Object {
       "flags": Object {
-        "rows": Array [],
+        "rows": Array [
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ],
         "table": Object {
+          "dirty": false,
           "fresh": true,
           "timeStamp": Object {
             "nanoseconds": 0,

--- a/src/malcolmWidgets/table/__snapshots__/table.container.test.js.snap
+++ b/src/malcolmWidgets/table/__snapshots__/table.container.test.js.snap
@@ -90,39 +90,36 @@ exports[`Table container renders correctly 1`] = `
           "typeid": "malcolm:core/TableMeta:1.0",
           "writeable": true,
         },
-        "value": Object {
-          "mri": Array [
-            "PANDA:TTLIN1",
-            "PANDA:TTLIN2",
-            "PANDA:INENC1",
-            "PANDA:INENC2",
-          ],
-          "name": Array [
-            "TTLIN1",
-            "TTLIN2",
-            "INENC1",
-            "INENC2",
-          ],
-          "typeid": "malcolm:core/Table:1.0",
-          "visible": Array [
-            false,
-            false,
-            false,
-            false,
-          ],
-          "x": Array [
-            0,
-            0,
-            0,
-            0,
-          ],
-          "y": Array [
-            0,
-            0,
-            0,
-            0,
-          ],
-        },
+        "value": Array [
+          Object {
+            "mri": "PANDA:TTLIN1",
+            "name": "TTLIN1",
+            "visible": false,
+            "x": 0,
+            "y": 0,
+          },
+          Object {
+            "mri": "PANDA:TTLIN2",
+            "name": "TTLIN2",
+            "visible": false,
+            "x": 0,
+            "y": 0,
+          },
+          Object {
+            "mri": "PANDA:INENC1",
+            "name": "INENC1",
+            "visible": false,
+            "x": 0,
+            "y": 0,
+          },
+          Object {
+            "mri": "PANDA:INENC2",
+            "name": "INENC2",
+            "visible": false,
+            "x": 0,
+            "y": 0,
+          },
+        ],
       },
       "raw": Object {
         "alarm": Object {
@@ -243,11 +240,6 @@ exports[`Table container renders correctly 1`] = `
   footerItems={
     Array [
       <WithStyles(Typography)>
-        State is edited:
-         
-        false
-    </WithStyles(Typography)>,
-      <WithStyles(Typography)>
         Up to date!
     </WithStyles(Typography)>,
       <WithStyles(ButtonAction)
@@ -339,39 +331,36 @@ exports[`Table container renders correctly 1`] = `
         "typeid": "malcolm:core/TableMeta:1.0",
         "writeable": true,
       },
-      "value": Object {
-        "mri": Array [
-          "PANDA:TTLIN1",
-          "PANDA:TTLIN2",
-          "PANDA:INENC1",
-          "PANDA:INENC2",
-        ],
-        "name": Array [
-          "TTLIN1",
-          "TTLIN2",
-          "INENC1",
-          "INENC2",
-        ],
-        "typeid": "malcolm:core/Table:1.0",
-        "visible": Array [
-          false,
-          false,
-          false,
-          false,
-        ],
-        "x": Array [
-          0,
-          0,
-          0,
-          0,
-        ],
-        "y": Array [
-          0,
-          0,
-          0,
-          0,
-        ],
-      },
+      "value": Array [
+        Object {
+          "mri": "PANDA:TTLIN1",
+          "name": "TTLIN1",
+          "visible": false,
+          "x": 0,
+          "y": 0,
+        },
+        Object {
+          "mri": "PANDA:TTLIN2",
+          "name": "TTLIN2",
+          "visible": false,
+          "x": 0,
+          "y": 0,
+        },
+        Object {
+          "mri": "PANDA:INENC1",
+          "name": "INENC1",
+          "visible": false,
+          "x": 0,
+          "y": 0,
+        },
+        Object {
+          "mri": "PANDA:INENC2",
+          "name": "INENC2",
+          "visible": false,
+          "x": 0,
+          "y": 0,
+        },
+      ],
     }
   }
   setFlag={[Function]}

--- a/src/malcolmWidgets/table/__snapshots__/table.container.test.js.snap
+++ b/src/malcolmWidgets/table/__snapshots__/table.container.test.js.snap
@@ -6,6 +6,7 @@ exports[`Table container renders correctly 1`] = `
   attribute={
     Object {
       "calculated": Object {
+        "dirty": false,
         "name": "layout",
         "path": Array [
           "test1",

--- a/src/malcolmWidgets/table/table.component.js
+++ b/src/malcolmWidgets/table/table.component.js
@@ -54,11 +54,19 @@ const styles = theme => ({
   blankCell: {
     backgroundColor: 'rgb(48, 48, 48)',
     textAlign: 'Center',
+    padding: '2px',
   },
   textBody: {
     backgroundColor: emphasize(theme.palette.background.paper, 0.1),
     textAlign: 'Center',
     padding: '2px',
+  },
+  button: {
+    width: '22px',
+    height: '22px',
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
   },
 });
 
@@ -155,22 +163,43 @@ const WidgetTable = props => {
               <TableRow className={props.classes.rowFormat} key={row}>
                 {[
                   <TableCell
-                    className={props.classes.textBody}
+                    className={
+                      flags.table.selectedRow === row
+                        ? props.classes.blankCell
+                        : props.classes.textBody
+                    }
                     padding="none"
                     key={-1}
                   >
-                    <AttributeAlarm
-                      alarmSeverity={
-                        flags.rows[row] &&
-                        (flags.rows[row]._dirty || flags.rows[row]._isChanged)
-                          ? AlarmStates.DIRTY
-                          : AlarmStates.NO_ALARM
+                    <IconButton
+                      className={props.classes.button}
+                      disableRipple
+                      onClick={() =>
+                        props.setFlag(
+                          props.attribute.calculated.path,
+                          row,
+                          'selected',
+                          { selected: true }
+                        )
                       }
-                    />
+                    >
+                      <AttributeAlarm
+                        alarmSeverity={
+                          flags.rows[row] &&
+                          (flags.rows[row]._dirty || flags.rows[row]._isChanged)
+                            ? AlarmStates.DIRTY
+                            : AlarmStates.NO_ALARM
+                        }
+                      />
+                    </IconButton>
                   </TableCell>,
                   ...columnLabels.map((label, column) => (
                     <TableCell
-                      className={props.classes.textBody}
+                      className={
+                        flags.table.selectedRow === row
+                          ? props.classes.blankCell
+                          : props.classes.textBody
+                      }
                       padding="none"
                       key={[row, column]}
                     >
@@ -257,6 +286,9 @@ WidgetTable.propTypes = {
     rows: PropTypes.arrayOf(PropTypes.shape({})),
     flags: PropTypes.shape({
       rows: PropTypes.shape({}),
+      table: PropTypes.shape({
+        selectedRow: PropTypes.number,
+      }),
     }),
     hasIncompleteRow: PropTypes.bool,
     labels: PropTypes.arrayOf(PropTypes.string),
@@ -268,6 +300,7 @@ WidgetTable.propTypes = {
     }),
   }),
   classes: PropTypes.shape({
+    button: PropTypes.string,
     tableBody: PropTypes.string,
     headerLayoutNoScroll: PropTypes.string,
     headerLayout: PropTypes.string,

--- a/src/malcolmWidgets/table/table.component.js
+++ b/src/malcolmWidgets/table/table.component.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import { emphasize } from '@material-ui/core/styles/colorManipulator';
 import IconButton from '@material-ui/core/IconButton';
-import { Add } from '@material-ui/icons';
+import { AddCircle } from '@material-ui/icons';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -191,7 +191,7 @@ const WidgetTable = props => {
                 key={rowNames.length}
               >
                 <TableCell
-                  className={props.classes.incompleteRowFormat}
+                  className={props.classes.blankCell}
                   padding="none"
                   key={[rowNames.length, 0]}
                 >
@@ -203,7 +203,7 @@ const WidgetTable = props => {
                       )
                     }
                   >
-                    <Add />
+                    <AddCircle style={{ width: '30px', height: '30px' }} />
                   </IconButton>
                 </TableCell>
               </TableRow>

--- a/src/malcolmWidgets/table/table.component.js
+++ b/src/malcolmWidgets/table/table.component.js
@@ -282,7 +282,7 @@ WidgetTable.propTypes = {
     }),
   }).isRequired,
   localState: PropTypes.shape({
-    value: PropTypes.shape({}),
+    value: PropTypes.arrayOf(PropTypes.shape({})),
     rows: PropTypes.arrayOf(PropTypes.shape({})),
     flags: PropTypes.shape({
       rows: PropTypes.shape({}),

--- a/src/malcolmWidgets/table/table.component.test.js
+++ b/src/malcolmWidgets/table/table.component.test.js
@@ -2,21 +2,38 @@ import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 
 import WidgetTable from './table.component';
-import { harderAttribute } from './table.stories';
+import { harderAttribute, expectedCopy } from './table.stories';
 
 describe('WidgetTable', () => {
   let shallow;
   let mount;
+  let localState;
 
   beforeEach(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
+    localState = expectedCopy;
   });
 
-  it('renders correctly', () => {
+  it('renders correctly with no selected row', () => {
     const wrapper = shallow(
       <WidgetTable
         attribute={harderAttribute}
+        localState={localState}
+        eventHandler={() => {}}
+        setFlag={() => {}}
+        addRow={() => {}}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('renders correctly with selected row', () => {
+    localState.flags.table.selectedRow = 1;
+    const wrapper = shallow(
+      <WidgetTable
+        attribute={harderAttribute}
+        localState={localState}
         eventHandler={() => {}}
         setFlag={() => {}}
         addRow={() => {}}
@@ -123,5 +140,33 @@ describe('WidgetTable', () => {
       .simulate('click');
     expect(addRow.mock.calls.length).toEqual(1);
     expect(addRow.mock.calls[0]).toEqual([['test1', 'layout'], 4]);
+  });
+
+  it('adds row on button click', () => {
+    const setFlag = jest.fn();
+    const wrapper = mount(
+      <WidgetTable
+        attribute={harderAttribute}
+        eventHandler={() => {}}
+        setFlag={setFlag}
+        addRow={() => {}}
+      />
+    );
+    const buttons = wrapper.find('button');
+    buttons.at(0).simulate('click');
+    buttons.at(3).simulate('click');
+    expect(setFlag.mock.calls.length).toEqual(2);
+    expect(setFlag.mock.calls[0]).toEqual([
+      ['test1', 'layout'],
+      0,
+      'selected',
+      { selected: true },
+    ]);
+    expect(setFlag.mock.calls[1]).toEqual([
+      ['test1', 'layout'],
+      3,
+      'selected',
+      { selected: true },
+    ]);
   });
 });

--- a/src/malcolmWidgets/table/table.component.test.js
+++ b/src/malcolmWidgets/table/table.component.test.js
@@ -31,7 +31,15 @@ describe('WidgetTable', () => {
       <WidgetTable
         attribute={harderAttribute}
         localState={{
-          value: harderAttribute.raw.value,
+          value: harderAttribute.raw.value[
+            Object.keys(harderAttribute.raw.meta.elements)[0]
+          ].map((val, row) => {
+            const rowData = {};
+            Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+              rowData[label] = harderAttribute.raw.value[label][row];
+            });
+            return rowData;
+          }),
           meta: harderAttribute.raw.meta,
           labels: Object.keys(harderAttribute.raw.meta.elements),
           flags: {
@@ -111,7 +119,7 @@ describe('WidgetTable', () => {
     );
     wrapper
       .find('button')
-      .first()
+      .last()
       .simulate('click');
     expect(addRow.mock.calls.length).toEqual(1);
     expect(addRow.mock.calls[0]).toEqual([['test1', 'layout'], 4]);

--- a/src/malcolmWidgets/table/table.container.js
+++ b/src/malcolmWidgets/table/table.container.js
@@ -23,13 +23,6 @@ const TableContainer = props => {
 
   const footerItems = [
     ...props.footerItems,
-    <Typography>
-      State is edited:{' '}
-      {`${!!(
-        props.attribute.localState &&
-        props.attribute.localState.flags.table.dirty
-      )}`}
-    </Typography>,
     props.attribute.localState &&
     props.attribute.localState.flags.table.fresh ? (
       <Typography>Up to date!</Typography>

--- a/src/malcolmWidgets/table/table.container.js
+++ b/src/malcolmWidgets/table/table.container.js
@@ -37,7 +37,7 @@ const TableContainer = props => {
       text="Discard changes"
     />,
     <ButtonAction
-      clickAction={() => props.putTable(path, props.attribute.localState.value)}
+      clickAction={() => props.putTable(path, props.attribute.localState)}
       text="Submit"
     />,
   ];
@@ -80,7 +80,17 @@ const mapDispatchToProps = dispatch => ({
   copyTable: path => {
     dispatch(malcolmCopyValue(path));
   },
-  putTable: (path, value) => {
+  putTable: (path, tableState) => {
+    const value = {};
+    tableState.labels.forEach(label => {
+      value[label] = [];
+    });
+    tableState.value.forEach(row => {
+      tableState.labels.forEach(label => {
+        value[label] = [...value[label], row[label]];
+      });
+    });
+
     dispatch(malcolmSetFlag(path, 'pending', true));
     dispatch(malcolmPutAction(path, value));
   },

--- a/src/malcolmWidgets/table/table.container.test.js
+++ b/src/malcolmWidgets/table/table.container.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import configureStore from 'redux-mock-store';
 import WidgetTable from './table.container';
-import { harderAttribute } from './table.stories';
+import { harderAttribute, expectedCopy } from './table.stories';
 import {
   malcolmSetFlag,
   malcolmSetTableFlag,
@@ -32,26 +32,9 @@ describe('Table container', () => {
         },
       },
     };
-    state.malcolm.blocks.test1.attributes[0].localState = {
-      value: harderAttribute.raw.value[
-        Object.keys(harderAttribute.raw.meta.elements)[0]
-      ].map((val, row) => {
-        const rowData = {};
-        Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
-          rowData[label] = harderAttribute.raw.value[label][row];
-        });
-        return rowData;
-      }),
-      meta: harderAttribute.raw.meta,
-      labels: Object.keys(harderAttribute.raw.meta.elements),
-      flags: {
-        rows: [],
-        table: {
-          fresh: true,
-          timeStamp: JSON.parse(JSON.stringify(harderAttribute.raw.timeStamp)),
-        },
-      },
-    };
+    state.malcolm.blocks.test1.attributes[0].localState = JSON.parse(
+      JSON.stringify(expectedCopy)
+    );
   });
 
   it('renders correctly', () => {

--- a/src/malcolmWidgets/table/table.container.test.js
+++ b/src/malcolmWidgets/table/table.container.test.js
@@ -33,7 +33,15 @@ describe('Table container', () => {
       },
     };
     state.malcolm.blocks.test1.attributes[0].localState = {
-      value: JSON.parse(JSON.stringify(harderAttribute.raw.value)),
+      value: harderAttribute.raw.value[
+        Object.keys(harderAttribute.raw.meta.elements)[0]
+      ].map((val, row) => {
+        const rowData = {};
+        Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+          rowData[label] = harderAttribute.raw.value[label][row];
+        });
+        return rowData;
+      }),
       meta: harderAttribute.raw.meta,
       labels: Object.keys(harderAttribute.raw.meta.elements),
       flags: {
@@ -138,10 +146,8 @@ describe('Table container', () => {
     const wrapper = mount(
       <WidgetTable blockName="test1" attributeName="layout" store={testStore} />
     );
-    wrapper
-      .find('button')
-      .first()
-      .simulate('click');
+    const buttons = wrapper.find('button');
+    buttons.at(buttons.length - 3).simulate('click');
     expect(testStore.getActions().length).toEqual(1);
     expect(testStore.getActions()[0]).toEqual(
       malcolmUpdateTable(['test1', 'layout'], { insertRow: true }, 4)
@@ -153,10 +159,8 @@ describe('Table container', () => {
     const wrapper = mount(
       <WidgetTable blockName="test1" attributeName="layout" store={testStore} />
     );
-    wrapper
-      .find('button')
-      .at(1)
-      .simulate('click');
+    const buttons = wrapper.find('button');
+    buttons.at(buttons.length - 2).simulate('click');
     expect(testStore.getActions().length).toEqual(1);
     expect(testStore.getActions()[0]).toEqual(
       malcolmCopyValue(['test1', 'layout'])
@@ -176,8 +180,10 @@ describe('Table container', () => {
     expect(testStore.getActions()[0]).toEqual(
       malcolmSetFlag(['test1', 'layout'], 'pending', true)
     );
+    const expectedSent = harderAttribute.raw.value;
+    delete expectedSent.typeid;
     expect(testStore.getActions()[1]).toEqual(
-      malcolmPutAction(['test1', 'layout'], harderAttribute.raw.value)
+      malcolmPutAction(['test1', 'layout'], expectedSent)
     );
   });
 });

--- a/src/malcolmWidgets/table/table.stories.js
+++ b/src/malcolmWidgets/table/table.stories.js
@@ -83,6 +83,32 @@ export const harderAttribute = {
   },
 };
 
+const rowValues = harderAttribute.raw.value[
+  Object.keys(harderAttribute.raw.meta.elements)[0]
+].map((val, row) => {
+  const rowData = {};
+  Object.keys(harderAttribute.raw.meta.elements).forEach(label => {
+    rowData[label] = harderAttribute.raw.value[label][row];
+  });
+  return rowData;
+});
+
+export const expectedCopy = {
+  value: JSON.parse(JSON.stringify(rowValues)),
+  meta: JSON.parse(JSON.stringify(harderAttribute.raw.meta)),
+  labels: Object.keys(harderAttribute.raw.meta.elements),
+  flags: {
+    rows: harderAttribute.raw.value[
+      Object.keys(harderAttribute.raw.meta.elements)[0]
+    ].map(() => ({})),
+    table: {
+      dirty: false,
+      fresh: true,
+      timeStamp: JSON.parse(JSON.stringify(harderAttribute.raw.timeStamp)),
+    },
+  },
+};
+
 const table = (
   <ContainedTable
     attribute={harderAttribute}

--- a/src/malcolmWidgets/table/table.stories.js
+++ b/src/malcolmWidgets/table/table.stories.js
@@ -10,6 +10,7 @@ export const harderAttribute = {
   calculated: {
     name: 'layout',
     path: ['test1', 'layout'],
+    dirty: false,
   },
   raw: {
     typeid: 'epics:nt/NTTable:1.0',


### PR DESCRIPTION
## Description

- Added alarm icons to table rows. 
- Added a "selected" row flag (which currently just highlights the row) triggered by clicking the alarm icon for that row.
- Refactored table local state to be an array of objects, each containing all the values for one row.
- Added a new icon to attributeAlarm to show a combined dirty & error state.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/PANDA:SEQ1/table
- click one of the row icons
- click into any text input for any row and type an invalid input (e.g. "dog")
- click "submit"
- see the new error icon (in the parent block details pane and at the bottom left of the middle pane)

## Agile board tracking

connect to #228 
connect to #225 
closes #228 
closes #225