### PR TITLE
Feature/subelement info #247

### DIFF
--- a/demos/sprint6/2018-07-30_bryan_demos
+++ b/demos/sprint6/2018-07-30_bryan_demos
@@ -1,0 +1,24 @@
+1. navigate to localhost:3000/PANDA:SEQ1
+
+Dirty state in alarm icon
+-------------------------
+2. click in prescale field and observe alarm icon change to 'dirty' state
+
+Attribute info pane
+-------------------
+3. click on table 'i' icon, see table in middle pane and attribute info in right.
+4. edit any row (or add one); see the row's alarm icon and the local state discard button in the info pane (click this button and see the table revert to it's original state).
+
+Table row alarm icon/info pane & sub-element url route
+--------------------------------
+5. click on the info icon for any row (add a new one first if necessary). See the route change in the top and the info pane change to row info.
+6. try adding rows above and below
+
+Refactor table local state
+--------------------------
+7. See table.reducer if desired (line 67, localState.value is now an array of row objects rather than an object of column arrays)
+
+Attribute structure
+-------------------
+8. attributes now have raw property containing all information received from malcolm as-is and a calculated property for anything added by malcolmJS (note, tables also have a localState property)
+

--- a/src/infoDetails/infoBuilders.js
+++ b/src/infoDetails/infoBuilders.js
@@ -93,11 +93,13 @@ export const buildAttributeInfo = props => {
     } else if (attribute.localState) {
       const row = parseInt(props.subElement[1], 10);
       const rowFlags = attribute.localState.flags.rows[row];
+      const isNewRow =
+        row >= attribute.raw.value[attribute.localState.labels[0]].length;
       info.localState = {
         label: 'Row local state',
         value: {
           buttonLabel: 'Discard',
-          disabled: !(rowFlags._dirty || rowFlags._isChanged),
+          disabled: !(rowFlags._dirty || rowFlags._isChanged) || isNewRow,
         },
         inline: true,
         tag: 'info:button',
@@ -109,7 +111,7 @@ export const buildAttributeInfo = props => {
         dataRow[label] =
           row < attribute.raw.value[label].length
             ? attribute.raw.value[label][row]
-            : 'n/a';
+            : 'undefined';
       });
       info.rowValue = {
         label: 'Row remote state',

--- a/src/malcolm/reducer/table.reducer.js
+++ b/src/malcolm/reducer/table.reducer.js
@@ -121,6 +121,9 @@ export const updateTableLocal = (state, payload) => {
           _isChanged: true,
         });
       }
+      attribute.localState.flags.rows.slice(insertAt).forEach((row, index) => {
+        attribute.localState.flags.rows[index + insertAt]._isChanged = true;
+      });
     } else {
       attribute.localState.value[payload.row] = payload.value;
 

--- a/src/malcolm/reducer/table.reducer.test.js
+++ b/src/malcolm/reducer/table.reducer.test.js
@@ -172,6 +172,15 @@ describe('Table reducer', () => {
     expect(testState.blocks.block1.attributes[0].localState.value).toEqual(
       splicedValue
     );
+    expect(
+      testState.blocks.block1.attributes[0].localState.flags.rows
+        .slice(1)
+        .map(row => row._isChanged)
+    ).toEqual(
+      testState.blocks.block1.attributes[0].localState.flags.rows
+        .slice(1)
+        .map(() => true)
+    );
   });
 
   it('updates existing local state copy', () => {


### PR DESCRIPTION
## Description
Bugfixes for table row info pane + sprint 6 review demos

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/PANDA:SEQ1/table
- add three rows then click submit
- add another new row and click its alarm icon to open the info pane
- check that the "discard" button for the new row is disabled.
- click submit again
- click on the info icon for the second row, then click insert row below
- check that all rows below the second are now flagged as dirty by their alarm icons

## Agile board tracking

connect to #243 
closes #243