### PR TITLE
Made sure the layout engine gets recalculated when the route changes

### DIFF
--- a/src/malcolm/reducer/malcolmReducer.js
+++ b/src/malcolm/reducer/malcolmReducer.js
@@ -492,9 +492,15 @@ const malcolmReducer = (state = initialMalcolmState, action = {}) => {
 
       updatedState = NavigationReducer.updateNavTypes(updatedState);
 
+      updatedState.layout = layoutReducer.processLayout(updatedState);
+
       return {
         ...updatedState,
-        layout: layoutReducer.processLayout(updatedState),
+        layoutEngine: layoutReducer.buildLayoutEngine(
+          updatedState.layout,
+          updatedState.layoutState.selectedBlocks,
+          undefined
+        ),
       };
 
     case MalcolmCleanBlocks:

--- a/src/malcolm/reducer/malcolmReducer.test.js
+++ b/src/malcolm/reducer/malcolmReducer.test.js
@@ -67,6 +67,8 @@ describe('malcolm reducer', () => {
     MethodReducer.mockImplementation(s => s);
     NavigationReducer.updateNavTypes.mockImplementation(s => s);
     NavigationReducer.updateNavigationPath.mockImplementation(s => s);
+    LayoutReducer.buildLayoutEngine.mockClear();
+    LayoutReducer.processLayout.mockClear();
     LayoutReducer.processLayout.mockImplementation(() => ({
       blocks: [{ loading: true }],
     }));
@@ -401,6 +403,8 @@ describe('malcolm reducer', () => {
     state = malcolmReducer(state, action);
 
     expect(NavigationReducer.updateNavigationPath).toHaveBeenCalledTimes(1);
+    expect(LayoutReducer.processLayout).toHaveBeenCalledTimes(1);
+    expect(LayoutReducer.buildLayoutEngine).toHaveBeenCalledTimes(1);
   });
 
   it('does clean', () => {


### PR DESCRIPTION
## Description

Fixed the layout view button, the problem was that the engine state wasn't recalculated on a route change.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- run the site and navigate to `/gui/PANDA` and click on the `View` button for the layout.

## Agile board tracking

connect to #260 
closes #260 
