### PR TITLE
Feature/link to invisible block #176

### DIFF
--- a/src/blockDetails/__snapshots__/blockDetails.test.js.snap
+++ b/src/blockDetails/__snapshots__/blockDetails.test.js.snap
@@ -134,6 +134,7 @@ exports[`Block Details renders methods correctly 1`] = `
     />
     <Connect(WithStyles(MethodDetails))
       attributeName="save"
+      key="save"
     />
   </div>
 </div>

--- a/src/blockDetails/blockDetails.component.js
+++ b/src/blockDetails/blockDetails.component.js
@@ -113,6 +113,7 @@ const displayAttributes = props => {
         ))}
         {props.methods.map(method => (
           <MethodDetails
+            key={method.calculated.name}
             blockName={props.blockName}
             attributeName={method.calculated.name}
           />

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,11 @@ if (process.env.NODE_ENV === 'production' && !process.env.REACT_APP_E2E) {
 
 store.dispatch(configureSocket(worker));
 
+// temporary logging whilst Tom measures performance on a real PANDA
+setInterval(() => {
+  console.log(Object.keys(store.getState().malcolm.blocks));
+}, 60000);
+
 const theme = createMuiTheme({
   palette: {
     type: 'dark',

--- a/src/infoDetails/infoElement.component.js
+++ b/src/infoDetails/infoElement.component.js
@@ -74,7 +74,7 @@ InfoElement.propTypes = {
   showLabel: PropTypes.bool,
   tag: PropTypes.string.isRequired,
   path: PropTypes.arrayOf(PropTypes.string),
-  value: PropTypes.oneOf(PropTypes.string, PropTypes.number, PropTypes.bool)
+  value: PropTypes.oneOf([PropTypes.string, PropTypes.number, PropTypes.bool])
     .isRequired,
   choices: PropTypes.arrayOf(PropTypes.string),
   classes: PropTypes.shape({

--- a/src/layout/block/BlockNodeModel.js
+++ b/src/layout/block/BlockNodeModel.js
@@ -21,7 +21,7 @@ class BlockNodeModel extends NodeModel {
       `${this.id}-${port.label}`,
       port.label,
       `${this.id}-${port.label}`,
-      port.portType
+      port
     );
 
     newPort.addMouseDownHandler(portMouseDown);

--- a/src/layout/blockPort/MalcolmPortModel.js
+++ b/src/layout/blockPort/MalcolmPortModel.js
@@ -3,9 +3,13 @@ import MalcolmLinkModel from '../link/link.model';
 
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["createLinkModel"] }] */
 class MalcolmPortModel extends DefaultPortModel {
-  constructor(isInput, name, label, id, portType) {
+  constructor(isInput, name, label, id, port) {
     super(isInput, name, label, id);
-    this.portType = portType;
+    if (port) {
+      this.portType = port.portType;
+      this.hiddenLink = port.hiddenLink;
+      this.value = port.value;
+    }
     this.addMouseDownHandler = this.addMouseDownHandler.bind(this);
   }
 

--- a/src/layout/blockPort/__snapshots__/blockPortWidget.test.js.snap
+++ b/src/layout/blockPort/__snapshots__/blockPortWidget.test.js.snap
@@ -28,6 +28,41 @@ exports[`BlockPortWidget input port renders correctly 1`] = `
 </div>
 `;
 
+exports[`BlockPortWidget input port renders correctly with hidden link 1`] = `
+<div
+  className="BlockPortWidget-container-1"
+>
+  <div
+    className="BlockPortWidget-hiddenLink-6"
+  >
+    <WithStyles(Typography)>
+      HIDDEN_BLOCK.VAL
+    </WithStyles(Typography)>
+  </div>
+  <div
+    className="port BlockPortWidget-port-2 malcolm-port "
+    data-name="val1"
+    data-nodeid="node1"
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    role="presentation"
+    style={
+      Object {
+        "background": "blue",
+        "marginRight": 3,
+      }
+    }
+  />
+  <WithStyles(Typography)
+    className="BlockPortWidget-portLabel-5"
+  >
+    val 1
+  </WithStyles(Typography)>
+</div>
+`;
+
 exports[`BlockPortWidget output port renders correctly 1`] = `
 <div
   className="BlockPortWidget-container-1"
@@ -53,5 +88,40 @@ exports[`BlockPortWidget output port renders correctly 1`] = `
       }
     }
   />
+</div>
+`;
+
+exports[`BlockPortWidget output port renders correctly with hidden link 1`] = `
+<div
+  className="BlockPortWidget-container-1"
+>
+  <WithStyles(Typography)
+    className="BlockPortWidget-portLabel-5"
+  >
+    val 1
+  </WithStyles(Typography)>
+  <div
+    className="port BlockPortWidget-port-2 malcolm-port "
+    data-name="val1"
+    data-nodeid="node1"
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    role="presentation"
+    style={
+      Object {
+        "background": "blue",
+        "marginLeft": 3,
+      }
+    }
+  />
+  <div
+    className="BlockPortWidget-hiddenLink-6"
+  >
+    <WithStyles(Typography)>
+      HIDDEN_BLOCK.VAL
+    </WithStyles(Typography)>
+  </div>
 </div>
 `;

--- a/src/layout/blockPort/blockPortWidget.component.js
+++ b/src/layout/blockPort/blockPortWidget.component.js
@@ -24,6 +24,18 @@ const styles = () => ({
   portLabel: {
     fontSize: 12,
   },
+  hiddenLink: {
+    position: 'absolute',
+    display: 'flex',
+    flexDirection: 'column',
+    paddingRight: 10,
+    borderBottom: '3px dashed rgba(255,255,255,0.5)',
+    right: '100%',
+    bottom: '40%',
+  },
+  hiddenLinkLine: {
+    width: '100%',
+  },
 });
 
 class BlockPortWidget extends BaseWidget {
@@ -50,6 +62,12 @@ class BlockPortWidget extends BaseWidget {
       background: this.state.selected ? portColour[100] : portColour[500],
     };
 
+    const hiddenLink = (
+      <div className={this.props.classes.hiddenLink}>
+        <Typography>{this.props.portValue}</Typography>
+        {/* <div className={this.props.classes.hiddenLinkLine}/> */}
+      </div>
+    );
     const port = (
       <div
         onMouseEnter={() => {
@@ -75,8 +93,10 @@ class BlockPortWidget extends BaseWidget {
 
     return (
       <div className={this.props.classes.container}>
+        {this.props.inputPort && this.props.hiddenLink ? hiddenLink : null}
         {this.props.inputPort ? port : label}
         {this.props.inputPort ? label : port}
+        {!this.props.inputPort && this.props.hiddenLink ? hiddenLink : null}
       </div>
     );
   }
@@ -91,6 +111,8 @@ export const mapStateToProps = (state, ownProps) => {
     portName: port.name,
     portLabel: port.label,
     portType: port.portType,
+    hiddenLink: port.hiddenLink,
+    portValue: port.value,
     mouseDownHandler: state.malcolm.layoutEngine.portMouseDown,
   };
 };

--- a/src/layout/blockPort/blockPortWidget.component.js
+++ b/src/layout/blockPort/blockPortWidget.component.js
@@ -65,7 +65,6 @@ class BlockPortWidget extends BaseWidget {
     const hiddenLink = (
       <div className={this.props.classes.hiddenLink}>
         <Typography>{this.props.portValue}</Typography>
-        {/* <div className={this.props.classes.hiddenLinkLine}/> */}
       </div>
     );
     const port = (

--- a/src/layout/blockPort/blockPortWidget.test.js
+++ b/src/layout/blockPort/blockPortWidget.test.js
@@ -62,8 +62,40 @@ describe('BlockPortWidget', () => {
     expect(wrapper.dive()).toMatchSnapshot();
   });
 
+  it('input port renders correctly with hidden link', () => {
+    port.in = true;
+    port.hiddenLink = true;
+    port.value = 'HIDDEN_BLOCK.VAL';
+
+    const wrapper = shallow(
+      <BlockPortWidget
+        nodeId="node1"
+        portId="val1"
+        store={mockStore(state)}
+        theme={theme}
+      />
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
   it('output port renders correctly', () => {
     port.in = false;
+
+    const wrapper = shallow(
+      <BlockPortWidget
+        nodeId="node1"
+        portId="val1"
+        store={mockStore(state)}
+        theme={theme}
+      />
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
+  it('output port renders correctly with hidden link', () => {
+    port.in = false;
+    port.hiddenLink = true;
+    port.value = 'HIDDEN_BLOCK.VAL';
 
     const wrapper = shallow(
       <BlockPortWidget

--- a/src/malcolm/reducer/layout/layout.reducer.js
+++ b/src/malcolm/reducer/layout/layout.reducer.js
@@ -81,6 +81,24 @@ export const updateLayoutBlock = (layoutBlock, malcolmState) => {
   return layoutBlock;
 };
 
+const findHiddenLinks = layoutBlocks =>
+  layoutBlocks.map(block => {
+    const updatedBlock = block;
+    const connectedInputPorts = updatedBlock.ports.filter(
+      p => p.input && p.value !== p.tag
+    );
+
+    connectedInputPorts.forEach(port => {
+      const updatedPort = port;
+      const isOutputPortVisible = layoutBlocks.some(b =>
+        b.ports.some(p => p.tag === updatedPort.value)
+      );
+      updatedPort.hiddenLink = !isOutputPortVisible;
+    });
+
+    return updatedBlock;
+  });
+
 const processLayout = malcolmState => {
   const layout = {
     blocks: [],
@@ -95,10 +113,12 @@ const processLayout = malcolmState => {
     );
 
     if (attribute && attribute.calculated.layout) {
-      const layoutBlocks = attribute.calculated.layout.blocks
+      let layoutBlocks = attribute.calculated.layout.blocks
         .filter(b => b.visible)
         .map(b => offSetPosition(b, malcolmState.layoutState.layoutCenter))
         .map(b => updateLayoutBlock(b, malcolmState));
+
+      layoutBlocks = findHiddenLinks(layoutBlocks);
       layout.blocks = layoutBlocks;
     }
   }

--- a/src/malcolmWidgets/attributeDetails/attributeSelector/__snapshots__/attributeSelector.test.js.snap
+++ b/src/malcolmWidgets/attributeDetails/attributeSelector/__snapshots__/attributeSelector.test.js.snap
@@ -11,7 +11,7 @@ exports[`AttributeSelector selector function returns info:button and renders cor
     color="primary"
     disabled={true}
     onClick={[Function]}
-    variant=""
+    variant="flat"
   >
     testButton
   </WithStyles(Button)>

--- a/src/malcolmWidgets/buttonAction/__snapshots__/buttonAction.test.js.snap
+++ b/src/malcolmWidgets/buttonAction/__snapshots__/buttonAction.test.js.snap
@@ -9,7 +9,7 @@ exports[`ButtonAction renders correctly 1`] = `
     color="primary"
     disabled={false}
     onClick={[Function]}
-    variant=""
+    variant="flat"
   >
     View
   </WithStyles(Button)>

--- a/src/malcolmWidgets/buttonAction/buttonAction.component.js
+++ b/src/malcolmWidgets/buttonAction/buttonAction.component.js
@@ -22,7 +22,7 @@ const ButtonAction = props => (
   <div className={props.classes.container}>
     <Button
       color="primary"
-      variant={props.method ? 'raised' : ''}
+      variant={props.method ? 'raised' : 'flat'}
       className={props.classes.button}
       onClick={props.clickAction}
       disabled={props.disabled}

--- a/src/malcolmWidgets/method/methodViewer.component.js
+++ b/src/malcolmWidgets/method/methodViewer.component.js
@@ -161,11 +161,11 @@ MethodViewer.propTypes = {
   selectedParamMeta: PropTypes.shape({
     tags: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
-  selectedParamValue: PropTypes.oneOf(
+  selectedParamValue: PropTypes.oneOf([
     PropTypes.string,
     PropTypes.number,
-    PropTypes.object
-  ).isRequired,
+    PropTypes.object,
+  ]).isRequired,
   classes: PropTypes.shape({
     plainBackground: PropTypes.string,
     tableContainer: PropTypes.string,


### PR DESCRIPTION
## Description

Added support for hidden blocks on sink ports

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Run the site, go to the layout and put a block that contains the source port for a link in the bin, see that the link now appears as a dashed line to the value on the sink port.

## Agile board tracking

connect to #176 
connect to #177 
closes #176 
closes #177 
