### PR TITLE
Fixed layout scroll zoom behaviour

### DIFF
--- a/src/layout/__snapshots__/layout.test.js.snap
+++ b/src/layout/__snapshots__/layout.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Layout renders correctly 1`] = `
 <div
+  id="LayoutDiv"
   onDragOver={[Function]}
   onDrop={[Function]}
   onMouseUp={[Function]}
@@ -34,7 +35,7 @@ exports[`Layout renders correctly 1`] = `
         "testEngine": true,
       }
     }
-    inverseZoom={false}
+    inverseZoom={true}
     maxNumberPointsPerLink={0}
     smartRouting={false}
   />

--- a/src/layout/layout.component.js
+++ b/src/layout/layout.component.js
@@ -17,9 +17,26 @@ const Layout = props => {
   updatedProps.layoutEngine.clickHandler = props.clickHandler;
   updatedProps.layoutEngine.mouseDownHandler = props.mouseDownHandler;
   updatedProps.layoutEngine.portMouseDown = props.portMouseDown;
-
+  const layoutDiv = document.getElementById('LayoutDiv');
+  if (layoutDiv !== null) {
+    layoutDiv.addEventListener('wheel', event => {
+      if (event.deltaMode === event.DOM_DELTA_LINE) {
+        event.stopPropagation();
+        const customScroll = new WheelEvent('wheel', {
+          bubbles: event.bubbles,
+          deltaMode: event.DOM_DELTA_PIXEL,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          deltaX: event.deltaX,
+          deltaY: 20 * event.deltaY,
+        });
+        event.target.dispatchEvent(customScroll);
+      }
+    });
+  }
   return (
     <div
+      id="LayoutDiv"
       onDrop={event => props.makeBlockVisible(event, props.layoutEngine)}
       onDragOver={event => event.preventDefault()}
       onMouseUp={() => props.mouseDownHandler(false)}
@@ -35,6 +52,7 @@ const Layout = props => {
         diagramEngine={props.layoutEngine}
         // smartRouting
         maxNumberPointsPerLink={0}
+        inverseZoom
       />
     </div>
   );


### PR DESCRIPTION
## Description

set prop to invert direction (so it matches google maps) and added an event handler to the outer div which catches and re-emits the scroll event so it gives deltaY in pixels
(as per chrome/react-diagrams expects)

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/PANDA/layout (using firefox)
- try scrolling to zoom

## Agile board tracking

connect to #305 
closes #305