### PR TITLE
Bugfix/link info #309

### DIFF
--- a/src/layout/block/BlockNodeModel.js
+++ b/src/layout/block/BlockNodeModel.js
@@ -1,5 +1,6 @@
 import { NodeModel } from 'storm-react-diagrams';
 import MalcolmPortModel from '../blockPort/MalcolmPortModel';
+import { idSeparator } from '../layout.component';
 
 class BlockNodeModel extends NodeModel {
   constructor(label, description, mri) {
@@ -18,9 +19,9 @@ class BlockNodeModel extends NodeModel {
   addBlockPort(port, portMouseDown) {
     const newPort = new MalcolmPortModel(
       port.input,
-      `${this.id}-${port.label}`,
+      `${this.id}${idSeparator}${port.label}`,
       port.label,
-      `${this.id}-${port.label}`,
+      `${this.id}${idSeparator}${port.label}`,
       port
     );
 

--- a/src/layout/block/__snapshots__/blockWidget.component.test.js.snap
+++ b/src/layout/block/__snapshots__/blockWidget.component.test.js.snap
@@ -25,9 +25,9 @@ exports[`BlockWidget block renders correctly 1`] = `
       className="BlockWidget-inputPortsContainer-5"
     >
       <Connect(WithStyles(BlockPortWidget))
-        key="block1-in 1"
+        key="block1•in 1"
         nodeId="block1"
-        portId="block1-in 1"
+        portId="block1•in 1"
       />
     </div>
     <div
@@ -53,14 +53,14 @@ exports[`BlockWidget block renders correctly 1`] = `
       className="BlockWidget-outputPortsContainer-6"
     >
       <Connect(WithStyles(BlockPortWidget))
-        key="block1-out 1"
+        key="block1•out 1"
         nodeId="block1"
-        portId="block1-out 1"
+        portId="block1•out 1"
       />
       <Connect(WithStyles(BlockPortWidget))
-        key="block1-out 2"
+        key="block1•out 2"
         nodeId="block1"
-        portId="block1-out 2"
+        portId="block1•out 2"
       />
     </div>
   </div>

--- a/src/layout/layout.component.js
+++ b/src/layout/layout.component.js
@@ -11,6 +11,8 @@ import layoutAction, { selectPort } from '../malcolm/actions/layout.action';
 
 require('storm-react-diagrams/dist/style.min.css');
 
+export const idSeparator = '•';
+
 const Layout = props => {
   const updatedProps = props;
   updatedProps.layoutEngine.selectedHandler = props.selectHandler;
@@ -113,7 +115,7 @@ export const mapDispatchToProps = dispatch => ({
     if (type === 'malcolmjsblock') {
       dispatch(malcolmSelectBlock(id, isSelected));
     } else if (type === 'malcolmlink' && isSelected) {
-      const idComponents = id.split('-');
+      const idComponents = id.split(idSeparator);
       const blockMri = idComponents[2];
       const portName = idComponents[3];
       dispatch(navigationActions.updateChildPanelWithLink(blockMri, portName));

--- a/src/layout/layout.test.js
+++ b/src/layout/layout.test.js
@@ -121,7 +121,7 @@ describe('Layout', () => {
     const props = mapDispatchToProps(() => {});
     props.selectHandler(
       'malcolmlink',
-      'block1-output-PANDA:block1-input1',
+      'block1•output•PANDA:block1•input1',
       true
     );
     expect(navigationActions.updateChildPanelWithLink).toBeCalledWith(

--- a/src/malcolm/actions/autoLayout.action.js
+++ b/src/malcolm/actions/autoLayout.action.js
@@ -1,5 +1,6 @@
 /* eslint no-console: ["error", { allow: ["info", "error"] }] */
 import { malcolmPutAction, malcolmSetFlag } from '../malcolmActionCreators';
+import { idSeparator } from '../../layout/layout.component';
 
 const calculateHeight = (layoutEngine, mri) => {
   const zoomFactor = layoutEngine.diagramModel.zoom / 100;
@@ -35,7 +36,7 @@ const runAutoLayout = () => (dispatch, getState) => {
         portConstraints: 'FIXED_ORDER',
       },
       ports: b.ports.map((p, i) => ({
-        id: `${b.mri}-${p.label}`,
+        id: `${b.mri}${idSeparator}${p.label}`,
         properties: {
           side: p.input ? 'WEST' : 'EAST',
           index: p.input ? b.ports.length - i : i,

--- a/src/malcolm/actions/layout.action.js
+++ b/src/malcolm/actions/layout.action.js
@@ -12,9 +12,10 @@ import {
 } from '../malcolmActionCreators';
 import blockUtils from '../blockUtils';
 import { snackbarState } from '../../viewState/viewState.actions';
+import { idSeparator } from '../../layout/layout.component';
 
 const findPort = (blocks, id) => {
-  const path = id.split('-');
+  const path = id.split(idSeparator);
   const block = blocks.find(b => b.mri === path[0]);
   const port = block.ports.find(p => p.label === path[1]);
 
@@ -62,7 +63,9 @@ export const selectPort = (portId, start) => (dispatch, getState) => {
 
       // 2. update on the server
       const path = [
-        ...(startPort.input ? startPortForLink : endPortForLink).split('-'),
+        ...(startPort.input ? startPortForLink : endPortForLink).split(
+          idSeparator
+        ),
         'value',
       ];
 

--- a/src/malcolm/actions/layout.action.test.js
+++ b/src/malcolm/actions/layout.action.test.js
@@ -78,12 +78,12 @@ describe('layout actions', () => {
   });
 
   it('selectPort dispatches a select port notification', () => {
-    const action = selectPort('PANDA-enable', true);
+    const action = selectPort('PANDA•enable', true);
     action(dispatch, getState);
 
     expect(actions.length).toBeGreaterThanOrEqual(1);
     expect(actions[0].type).toEqual(MalcolmSelectPortType);
-    expect(actions[0].payload.portId).toEqual('PANDA-enable');
+    expect(actions[0].payload.portId).toEqual('PANDA•enable');
     expect(actions[0].payload.start).toBeTruthy();
   });
 
@@ -112,11 +112,11 @@ describe('layout actions', () => {
   };
 
   it('selectPort dispatches an update to the server when completing a link', () => {
-    runPortTest('PANDA-start', 'PANDA-enable');
+    runPortTest('PANDA•start', 'PANDA•enable');
   });
 
   it('selectPort handles ports being the wrong way round', () => {
-    runPortTest('PANDA-enable', 'PANDA-start');
+    runPortTest('PANDA•enable', 'PANDA•start');
   });
 
   it('deleteBlocks makes the block invisible', () => {

--- a/src/malcolm/reducer/layout/layout.reducer.js
+++ b/src/malcolm/reducer/layout/layout.reducer.js
@@ -11,6 +11,7 @@ import BlockNodeFactory from '../../../layout/block/BlockNodeFactory';
 import BlockNodeModel from '../../../layout/block/BlockNodeModel';
 import MalcolmLinkFactory from '../../../layout/link/link.factory';
 import { sinkPort, sourcePort } from '../../malcolmConstants';
+import { idSeparator } from '../../../layout/layout.component';
 
 export const buildPorts = block => {
   const inputs = blockUtils.findAttributesWithTag(block, sinkPort);
@@ -189,7 +190,7 @@ const shiftIsPressed = (malcolmState, payload) => ({
 });
 
 const findPort = (blocks, id) => {
-  const path = id.split('-');
+  const path = id.split(idSeparator);
   const block = blocks.find(b => b.mri === path[0]);
   const port = block.ports.find(p => p.label === path[1]);
 
@@ -317,7 +318,8 @@ const buildLayoutEngine = (layout, selectedBlocks, layoutEngineView) => {
     const startNode = nodes.find(n => n.id === b.mri);
     if (startNode) {
       linkStarts.forEach(start => {
-        const startPort = startNode.ports[`${b.mri}-${start.label}`];
+        const startPort =
+          startNode.ports[`${b.mri}${idSeparator}${start.label}`];
 
         if (startPort !== undefined) {
           // need to find the target port and link them together
@@ -334,10 +336,11 @@ const buildLayoutEngine = (layout, selectedBlocks, layoutEngineView) => {
             const endNode = nodes.find(n => n.id === endBlock.mri);
 
             if (endNode) {
-              const endPort = endNode.ports[`${endBlock.mri}-${end.label}`];
+              const endPort =
+                endNode.ports[`${endBlock.mri}${idSeparator}${end.label}`];
 
               const newLink = endPort.link(startPort);
-              newLink.id = `${endPort.name}-${startPort.name}`;
+              newLink.id = `${endPort.name}${idSeparator}${startPort.name}`;
               links.push(newLink);
             }
           }

--- a/src/malcolm/reducer/layout/layout.reducer.test.js
+++ b/src/malcolm/reducer/layout/layout.reducer.test.js
@@ -257,7 +257,7 @@ describe('Layout Reducer', () => {
 
   it('selectPortForLink optimistically adds a link if the end port is being set', () => {
     let state = buildMalcolmState();
-    state.layoutState.startPortForLink = 'PANDA-start';
+    state.layoutState.startPortForLink = 'PANDA•start';
     state.layout.blocks = [
       {
         mri: 'PANDA',
@@ -268,10 +268,10 @@ describe('Layout Reducer', () => {
       },
     ];
 
-    state = LayoutReducer.selectPortForLink(state, 'PANDA-end', false);
+    state = LayoutReducer.selectPortForLink(state, 'PANDA•end', false);
 
-    expect(state.layoutState.startPortForLink).toEqual('PANDA-start');
-    expect(state.layoutState.endPortForLink).toEqual('PANDA-end');
+    expect(state.layoutState.startPortForLink).toEqual('PANDA•start');
+    expect(state.layoutState.endPortForLink).toEqual('PANDA•end');
     expect(state.layout.blocks[0].ports[1].value).toEqual('START');
   });
 
@@ -336,13 +336,13 @@ describe('LayoutBuilder', () => {
     expect(engine.diagramModel.nodes.block1.icon).toEqual('icon1');
 
     expect(Object.keys(engine.diagramModel.nodes.block1.ports)).toEqual([
-      'block1-in1',
+      'block1•in1',
     ]);
-    expect(engine.diagramModel.nodes.block1.ports['block1-in1'].label).toEqual(
+    expect(engine.diagramModel.nodes.block1.ports['block1•in1'].label).toEqual(
       'in1'
     );
     expect(
-      engine.diagramModel.nodes.block1.ports['block1-in1'].in
+      engine.diagramModel.nodes.block1.ports['block1•in1'].in
     ).toBeTruthy();
   });
 
@@ -357,13 +357,13 @@ describe('LayoutBuilder', () => {
 
     const engine = LayoutReducer.buildLayoutEngine({ blocks }, []);
     expect(Object.keys(engine.diagramModel.links)).toEqual([
-      'block1-out1-block2-in1',
+      'block1•out1•block2•in1',
     ]);
     expect(
-      engine.diagramModel.links['block1-out1-block2-in1'].sourcePort.id
-    ).toEqual('block1-out1');
+      engine.diagramModel.links['block1•out1•block2•in1'].sourcePort.id
+    ).toEqual('block1•out1');
     expect(
-      engine.diagramModel.links['block1-out1-block2-in1'].targetPort.id
-    ).toEqual('block2-in1');
+      engine.diagramModel.links['block1•out1•block2•in1'].targetPort.id
+    ).toEqual('block2•in1');
   });
 });

--- a/src/malcolmWidgets/attributeDetails/__snapshots__/attributeDetails.test.js.snap
+++ b/src/malcolmWidgets/attributeDetails/__snapshots__/attributeDetails.test.js.snap
@@ -3,6 +3,7 @@
 exports[`AttributeDetails renders correctly 1`] = `
 <div
   className="AttributeDetails-div-1"
+  style={Object {}}
 >
   <WithStyles(Tooltip)
     id="1"

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Tooltip from '@material-ui/core/Tooltip';
 import IconButton from '@material-ui/core/IconButton';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import AttributeAlarm, {
   getAlarmState,
 } from './attributeAlarm/attributeAlarm.component';
@@ -58,8 +59,11 @@ const EMPTY_STRING = '';
 
 const AttributeDetails = props => {
   if (props.widgetTagIndex !== null) {
+    const rowHighlight = props.isMainAttribute
+      ? { backgroundColor: fade(props.theme.palette.secondary.main, 0.25) }
+      : {};
     return (
-      <div className={props.classes.div}>
+      <div className={props.classes.div} style={rowHighlight}>
         <Tooltip id="1" title={props.message} placement="bottom">
           <IconButton
             tabindex="-1"
@@ -111,6 +115,14 @@ AttributeDetails.propTypes = {
   }).isRequired,
   buttonClickHandler: PropTypes.func.isRequired,
   nameClickHandler: PropTypes.func.isRequired,
+  isMainAttribute: PropTypes.bool.isRequired,
+  theme: PropTypes.shape({
+    palette: PropTypes.shape({
+      secondary: PropTypes.shape({
+        main: PropTypes.string,
+      }),
+    }),
+  }).isRequired,
 };
 
 AttributeDetails.defaultProps = {
@@ -159,6 +171,7 @@ const mapStateToProps = (state, ownProps) => {
       attribute && attribute.raw && attribute.raw.meta
         ? attribute.raw.meta.label
         : EMPTY_STRING,
+    isMainAttribute: state.malcolm.mainAttribute === attribute.calculated.name,
   };
 };
 

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -171,7 +171,10 @@ const mapStateToProps = (state, ownProps) => {
       attribute && attribute.raw && attribute.raw.meta
         ? attribute.raw.meta.label
         : EMPTY_STRING,
-    isMainAttribute: state.malcolm.mainAttribute === attribute.calculated.name,
+    isMainAttribute:
+      attribute &&
+      attribute.calculated &&
+      state.malcolm.mainAttribute === attribute.calculated.name,
   };
 };
 


### PR DESCRIPTION
## Description

Fixed bug where hyphens in MRIs were breaking layout link creation and info; did this by changing link IDs to use unicode character "•" as a separator between MRI and port name instead of hyphens. Also refactored code so this separator is defined as a constant in layout.component.js 

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- change public/settings.json to connect to a simulator/PANDA with some hyphens in its MRIs
- npm start
- navigate to localhost:3000/gui/$(valid MRI with hyphens)/layout
- make and select some links

## Agile board tracking

connect to #309 
closes #309 
connect to #306 
closes #306 