### PR TITLE
Hid the horizontal scrollbar using css, I couldn't work out what was …

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
+  overflow-x: hidden;
 }
 
 @keyframes dash {
@@ -16,6 +17,4 @@ body {
 
 .srd-default-link--highlight-path {
   stroke: #f50057 !important;
-  stroke-dasharray: 10, 2;
-  animation: dash 1s linear infinite;
 }


### PR DESCRIPTION
…causing it

## Description

I've tried finding the component that's causing the overflow but I think it's somehow related to the drawer and the containing component using 100%. The only fix I can think of is to disable the x overflow on the `body` using css.

Also removed animation for links, still need to work on the colour later.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Start the site, go to http://localhost:3000/gui/PANDA/layout, click on the TTLOUT1 block, close the child panel again and see that there is now no horizontal scrollbar.

## Agile board tracking

connect to #303 
closes #303 
