### PR TITLE
Turned on the setting to prevent dangling links

### DIFF
--- a/src/layout/__snapshots__/layout.test.js.snap
+++ b/src/layout/__snapshots__/layout.test.js.snap
@@ -19,7 +19,7 @@ exports[`Layout renders correctly 1`] = `
   <DiagramWidget
     allowCanvasTranslation={true}
     allowCanvasZoom={true}
-    allowLooseLinks={true}
+    allowLooseLinks={false}
     deleteKeys={
       Array [
         46,

--- a/src/layout/layout.component.js
+++ b/src/layout/layout.component.js
@@ -54,6 +54,7 @@ const Layout = props => {
         diagramEngine={props.layoutEngine}
         // smartRouting
         maxNumberPointsPerLink={0}
+        allowLooseLinks={false}
         inverseZoom
       />
     </div>


### PR DESCRIPTION
## Description

Found a setting that allows us to turn off dangling links, so this story was a lot quicker than I expected.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Run the site, go to the layout and try to make a dangling link, drop it in an open space and it should disappear.

## Agile board tracking

connect to #327 
closes #327 
