### PR TITLE
Feature/style updates part2 #325

### DIFF
--- a/server/canned_data/Sub/PANDA/response_layout.json
+++ b/server/canned_data/Sub/PANDA/response_layout.json
@@ -459,7 +459,7 @@
           "tags": [
             "widget:flowgraph"
           ], 
-          "writeable": false, 
+          "writeable": true, 
           "label": "Layout", 
           "elements": {
             "name": {

--- a/server/canned_data/Sub/PANDA/response_layout.json
+++ b/server/canned_data/Sub/PANDA/response_layout.json
@@ -459,7 +459,7 @@
           "tags": [
             "widget:flowgraph"
           ], 
-          "writeable": true, 
+          "writeable": false, 
           "label": "Layout", 
           "elements": {
             "name": {

--- a/src/infoDetails/infoBuilders.js
+++ b/src/infoDetails/infoBuilders.js
@@ -327,6 +327,7 @@ export const linkInfo = props => {
       inline: true,
       tag: 'info:button',
       showLabel: false,
+      disabled: props.isLayoutLocked,
       functions: {
         clickHandler: () => {
           props.eventHandler([blockMri, portName, 'value'], portNullValue);

--- a/src/infoDetails/infoDetails.component.js
+++ b/src/infoDetails/infoDetails.component.js
@@ -72,7 +72,8 @@ export class InfoDetails extends React.Component {
       (props.subElement && props.subElement[0] === 'row') ||
       (props.linkBlockName && props.linkBlockName !== state.subElement) ||
       props.isMethodInfo ||
-      Object.keys(state.info).length === 0
+      Object.keys(state.info).length === 0 ||
+      props.isLayoutLocked !== state.isLayoutLocked
     ) {
       let newState;
       let subElement;
@@ -90,6 +91,7 @@ export class InfoDetails extends React.Component {
         attributeName: props.attributeName,
         subElement,
         isLinkInfo: !!props.isLinkInfo,
+        isLayoutLocked: props.isLayoutLocked,
       };
     }
     return state;
@@ -115,7 +117,8 @@ export class InfoDetails extends React.Component {
       (!!nextProps.linkBlockName &&
         nextProps.linkBlockName !== this.state.subElement) ||
       nextProps.isMethodInfo ||
-      Object.keys(this.state.info).length === 0
+      Object.keys(this.state.info).length === 0 ||
+      nextProps.isLayoutLocked !== this.props.isLayoutLocked
     );
   }
 
@@ -211,6 +214,7 @@ InfoDetails.propTypes = {
   infoClickHandler: PropTypes.func.isRequired,
   isMethodInfo: PropTypes.bool.isRequired,
   // isLinkInfo: PropTypes.bool.isRequired,
+  isLayoutLocked: PropTypes.bool.isRequired,
 };
 
 InfoDetails.defaultProps = {
@@ -299,6 +303,7 @@ const mapStateToProps = state => {
     isMethodInfo:
       attribute && attribute.calculated && attribute.calculated.isMethod,
     linkBlockName,
+    isLayoutLocked: state.malcolm.layout && state.malcolm.layout.locked,
   };
 };
 

--- a/src/layout/layout.component.js
+++ b/src/layout/layout.component.js
@@ -60,6 +60,7 @@ class Layout extends React.Component {
         onMouseUp={() => this.props.mouseDownHandler(false)}
         onKeyUp={event => {
           if (
+            !this.props.locked &&
             Object.keys(deleteKeys).includes(event.key) &&
             this.state.hasFocus
           ) {
@@ -86,7 +87,11 @@ class Layout extends React.Component {
           maxNumberPointsPerLink={0}
           allowLooseLinks={false}
           inverseZoom
-          deleteKeys={this.state.hasFocus ? Object.values(deleteKeys) : []}
+          deleteKeys={
+            !this.props.locked && this.state.hasFocus
+              ? Object.values(deleteKeys)
+              : []
+          }
         />
       </div>
     );
@@ -108,10 +113,12 @@ Layout.propTypes = {
   mouseDownHandler: PropTypes.func.isRequired,
   deleteSelected: PropTypes.func.isRequired,
   linkClickHandler: PropTypes.func.isRequired,
+  locked: PropTypes.bool.isRequired,
 };
 
 export const mapStateToProps = state => ({
   layoutEngine: state.malcolm.layoutEngine,
+  locked: state.malcolm.layout && state.malcolm.layout.locked,
 });
 
 let showBinTimeout = null;

--- a/src/mainMalcolmView/middlePanel.container.js
+++ b/src/mainMalcolmView/middlePanel.container.js
@@ -147,6 +147,7 @@ const findAttributeComponent = props => {
                 variant="fab"
                 color="secondary"
                 onClick={() => props.openPalette()}
+                disabled={props.layoutLocked}
               >
                 <AddIcon />
               </Button>
@@ -160,6 +161,7 @@ const findAttributeComponent = props => {
               color="secondary"
               // variant="raised"
               onClick={() => props.runAutoLayout()}
+              disabled={props.layoutLocked}
             >
               Auto layout
             </Button>
@@ -276,6 +278,7 @@ const mapStateToProps = state => {
     tags: attribute && attribute.raw.meta ? attribute.raw.meta.tags : [],
     typeId: attribute && attribute.raw.meta ? attribute.raw.meta.typeid : '',
     showBin: state.malcolm.layoutState.showBin,
+    layoutLocked: state.malcolm.layout && state.malcolm.layout.locked,
   };
 };
 

--- a/src/malcolm/actions/navigation.actions.js
+++ b/src/malcolm/actions/navigation.actions.js
@@ -37,8 +37,27 @@ const navigateToAttribute = (blockMri, attributeName) => (
   getState
 ) => {
   const state = getState().malcolm;
-  const { navigationLists } = state.navigation;
 
+  const attribute = blockUtils.findAttribute(
+    state.blocks,
+    blockMri,
+    attributeName
+  );
+
+  // subscribe to layout blocks
+  if (blockUtils.attributeHasTag(attribute, 'widget:flowgraph')) {
+    attribute.raw.value.visible.forEach((visible, i) => {
+      if (visible) {
+        const blockName = attribute.raw.value.mri[i];
+        if (!state.blocks[blockName]) {
+          dispatch(malcolmNewBlockAction(blockName, false, false));
+          dispatch(malcolmSubscribeAction([blockName, 'meta']));
+        }
+      }
+    });
+  }
+
+  const { navigationLists } = state.navigation;
   const matchingBlockNav = findBlockIndex(navigationLists, blockMri);
   if (matchingBlockNav > -1) {
     const newPath = `/gui/${navigationLists

--- a/src/malcolm/malcolmHandlers/attributeHandler.js
+++ b/src/malcolm/malcolmHandlers/attributeHandler.js
@@ -82,12 +82,28 @@ const processAttributes = (messages, getState, dispatch) => {
   const layoutMessages = messages.filter(msg =>
     msg.attributeDelta.meta.tags.some(t => t === 'widget:flowgraph')
   );
+
   if (layoutMessages.length > 0) {
-    LayoutHandler.layoutAttributeReceived(
-      layoutMessages[0].originalRequest.path,
-      getState,
-      dispatch
-    );
+    layoutMessages.forEach(msg => {
+      const { navigationLists } = getState().malcolm.navigation;
+      const { path } = msg.originalRequest;
+      const matchingNavComponentIndex = navigationLists.findIndex(
+        nav => nav.blockMri === path[0]
+      );
+
+      if (
+        matchingNavComponentIndex > -1 &&
+        navigationLists.length > matchingNavComponentIndex + 1 &&
+        navigationLists[matchingNavComponentIndex + 1].path ===
+          msg.originalRequest.path[1]
+      ) {
+        LayoutHandler.layoutAttributeReceived(
+          msg.originalRequest.path,
+          getState,
+          dispatch
+        );
+      }
+    });
   }
 };
 

--- a/src/malcolm/reducer/layout/layout.reducer.js
+++ b/src/malcolm/reducer/layout/layout.reducer.js
@@ -121,6 +121,8 @@ const processLayout = malcolmState => {
 
       layoutBlocks = findHiddenLinks(layoutBlocks);
       layout.blocks = layoutBlocks;
+
+      layout.locked = !attribute.raw.meta.writeable;
     }
   }
 
@@ -281,7 +283,7 @@ const makeBlockVisible = (state, payload) => {
 
 const showLayoutBin = (state, payload) => {
   const layoutState = { ...state.layoutState };
-  layoutState.showBin = payload.visible;
+  layoutState.showBin = !state.layout.locked && payload.visible;
 
   return {
     ...state,

--- a/src/malcolm/reducer/layout/layout.reducer.test.js
+++ b/src/malcolm/reducer/layout/layout.reducer.test.js
@@ -60,6 +60,12 @@ const buildMalcolmState = () => ({
           },
         },
         {
+          raw: {
+            meta: {
+              writeable: true,
+              tags: [],
+            },
+          },
           calculated: {
             name: 'layout',
             layout: {

--- a/src/malcolm/reducer/layout/layoutEngine.helper.js
+++ b/src/malcolm/reducer/layout/layoutEngine.helper.js
@@ -109,6 +109,10 @@ export const buildLayoutEngine = (
     });
   });
 
+  if (layout.locked) {
+    model.setLocked(true);
+  }
+
   engine.setDiagramModel(model);
 
   if (layoutEngineView) {


### PR DESCRIPTION
## Description

Disabled the layout when it's not writeable and also stopped the layout loading recursively until a user navigates to that layout.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Run the site, disable the layout (either using the disable method on a PANDA simulator or modifying the layout response directly on the dev server). Check that the blocks can't be moved and links can't be made.
- Also, navigate to `/gui/PANDA` and check the console for the malcolm state to see that only `.blocks` and `PANDA` are subscribed to. Click on the `View` button for the layout attribute and see the layout load on demand.

## Agile board tracking

connect to #325 
closes #325 
