### PR TITLE
Prevent nulls and undefined being sent to the server

### DIFF
--- a/src/malcolm/malcolmActionCreators.js
+++ b/src/malcolm/malcolmActionCreators.js
@@ -161,15 +161,15 @@ export const malcolmLayoutUpdatePosition = translation => (
 
   const { selectedBlocks } = state.layoutState;
   if (layoutAttribute) {
-    const updateLayoutIndices = selectedBlocks.map(b =>
-      layoutAttribute.raw.value.mri.findIndex(val => val === b)
-    );
+    const updateLayoutIndices = selectedBlocks
+      .map(b => layoutAttribute.raw.value.mri.findIndex(val => val === b))
+      .filter(i => i > -1); // ensure no nulls
     const updateLayout = {
       name: updateLayoutIndices.map(i => layoutAttribute.raw.value.name[i]),
       visible: updateLayoutIndices.map(
         i => layoutAttribute.raw.value.visible[i]
       ),
-      mri: selectedBlocks,
+      mri: updateLayoutIndices.map(i => layoutAttribute.raw.value.mri[i]),
       x: updateLayoutIndices.map(
         i => layoutAttribute.raw.value.x[i] + translation.x
       ),

--- a/src/malcolm/malcolmActionCreators.test.js
+++ b/src/malcolm/malcolmActionCreators.test.js
@@ -37,7 +37,7 @@ describe('Malcolm Action Creators', () => {
     expect(action.payload.child).toEqual(false);
   });
 
-  it('malcolmLayoutUpdatePosition updates position locally and then on the server', () => {
+  const runLayoutPositionUpdateTest = selectedBlocks => {
     const translation = { x: 10, y: 20 };
     const asyncAction = malcolmLayoutUpdatePosition(translation);
 
@@ -69,7 +69,7 @@ describe('Malcolm Action Creators', () => {
           'PANDA:CLOCKS': {},
         },
         layoutState: {
-          selectedBlocks: ['PANDA:CLOCKS'],
+          selectedBlocks,
         },
       },
     };
@@ -96,5 +96,13 @@ describe('Malcolm Action Creators', () => {
       x: [10],
       y: [20],
     });
+  };
+
+  it('malcolmLayoutUpdatePosition updates position locally and then on the server', () => {
+    runLayoutPositionUpdateTest(['PANDA:CLOCKS']);
+  });
+
+  it('malcolmLayoutUpdatePosition strips out nulls and undefined from selected blocks', () => {
+    runLayoutPositionUpdateTest(['PANDA:CLOCKS', null, undefined]);
   });
 });


### PR DESCRIPTION
## Description

I can't work out how to replicate this using the dev server but I've updated the code so it can't send null or undefined mri's to the server.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- Run the site and check that you can still move blocks on the layout

## Agile board tracking

connect to #316 
closes #316 
