### PR TITLE
Bugfix/block loading #380

### DIFF
--- a/src/blockDetails/__snapshots__/blockDetails.test.js.snap
+++ b/src/blockDetails/__snapshots__/blockDetails.test.js.snap
@@ -9,23 +9,30 @@ exports[`Block Details renders correctly when block not found 1`] = `
       align="left"
       style={
         Object {
+          "fontFamily": "Roboto",
           "whiteSpace": "pre",
         }
       }
     >
-                   __   __    _____     __   __ 
-                  |\\  \\ |\\  \\  |\\   __  \\  |\\  \\  |\\  \\ 
-                  \\ \\  \\\\_\\  \\ \\ \\  \\|\\   \\ \\ \\  \\\\_\\  \\ 
-                   \\ \\___    \\ \\ \\  \\_\\  \\ \\ \\ ___   \\ 
-                    \\|___|\\__\\ \\ \\_____\\ \\|___|\\__\\ 
-                           \\|__|  \\|_____|        \\|__| 
+                      __     __      _____      __     __ 
+                     |\\  \\  |\\  \\   |\\   __  \\  |\\  \\  |\\  \\ 
+                     \\ \\  \\\\_\\  \\ \\ \\  \\|\\  \\ \\ \\ \\\\_\\  \\ 
+                       \\ \\___     \\ \\ \\  \\_\\  \\ \\ \\ ___   \\ 
+                         \\|___|\\__\\ \\ \\_____\\ \\|___|\\__\\ 
+                                 \\|__|   \\|______|         \\|__| 
       
     </div>
     <br />
     <br />
-    Block not found! 
-    <br />
-    (hint: URLs are case sensitive)
+    <WithStyles(Typography)>
+      Block not found....yet
+    </WithStyles(Typography)>
+    <WithStyles(Typography)>
+      it may still be loading and appear later
+    </WithStyles(Typography)>
+    <WithStyles(Typography)>
+      (hint: URLs are case sensitive)
+    </WithStyles(Typography)>
   </div>
 </div>
 `;
@@ -67,14 +74,12 @@ exports[`Block Details renders correctly when metadata loaded and waiting for at
   className="BlockDetails-progressContainer-1"
 >
   <div>
-    <Connect(WithStyles(AttributeDetails))
-      attributeName="health"
-      key="health"
+    <WithStyles(CircularProgress)
+      color="secondary"
     />
-    <Connect(WithStyles(AttributeDetails))
-      attributeName="icon"
-      key="icon"
-    />
+    <WithStyles(Typography)>
+      Loading...
+    </WithStyles(Typography)>
   </div>
 </div>
 `;

--- a/src/blockDetails/blockDetails.component.js
+++ b/src/blockDetails/blockDetails.component.js
@@ -9,12 +9,12 @@ import AttributeDetails from '../malcolmWidgets/attributeDetails/attributeDetail
 import MethodDetails from '../malcolmWidgets/method/method.component';
 
 const ascii404 =
-  '              __     __      _____     __    __ \n' +
-  '             |\\  \\  |\\  \\   |\\   __  \\  |\\  \\  |\\  \\ \n' +
-  '             \\ \\  \\\\_\\  \\ \\ \\  \\|\\  \\ \\ \\  \\\\_\\  \\ \n' +
-  '               \\ \\___     \\ \\ \\  \\_\\  \\ \\ \\ ___   \\ \n' +
-  '                 \\|___|\\__\\ \\ \\_____\\ \\|___|\\__\\ \n' +
-  '                         \\|__|   \\|______|        \\|__| \n';
+  '                __     __      _____      __     __ \n' +
+  '               |\\  \\  |\\  \\   |\\   __  \\  |\\  \\  |\\  \\ \n' +
+  '               \\ \\  \\\\_\\  \\ \\ \\  \\|\\  \\ \\ \\ \\\\_\\  \\ \n' +
+  '                 \\ \\___     \\ \\ \\  \\_\\  \\ \\ \\ ___   \\ \n' +
+  '                   \\|___|\\__\\ \\ \\_____\\ \\|___|\\__\\ \n' +
+  '                           \\|__|   \\|______|         \\|__| \n';
 
 const styles = theme => ({
   progressContainer: {
@@ -28,17 +28,28 @@ const styles = theme => ({
 
 const ignoredAttributes = ['widget:icon'];
 
-export const isBlockLoading = (block, blockName, blockList) => {
+export const isBlockLoading = (
+  block,
+  blockName,
+  blockList,
+  navList,
+  shouldExist
+) => {
   if (blockList.length > 0) {
+    if (!shouldExist) {
+      return false;
+    }
     if (
       (block !== undefined && block.loading === 404) ||
-      (block === undefined && !blockList.includes(blockName))
+      (navList.length > 0 &&
+        block === undefined &&
+        !blockList.includes(blockName))
     ) {
       return 404;
     }
     return (
       block !== undefined &&
-      (block.loading || block.attributes.some(a => a.loading))
+      (block.loading || block.attributes.some(a => a.calculated.loading))
     );
   }
   return true;
@@ -200,10 +211,15 @@ const mapStateToProps = (state, ownProps, memory) => {
       ? state.malcolm.blocks[state.malcolm.childBlock]
       : undefined;
   }
+  const panelIsOpen = ownProps.parent
+    ? state.viewState.openParentPanel
+    : state.malcolm.childBlock !== undefined;
   const blockLoading = isBlockLoading(
     block,
     ownProps.parent ? state.malcolm.parentBlock : state.malcolm.childBlock,
-    blockList
+    blockList,
+    state.malcolm.navigation.navigationLists,
+    panelIsOpen
   );
   if (
     block &&

--- a/src/blockDetails/blockDetails.component.js
+++ b/src/blockDetails/blockDetails.component.js
@@ -9,12 +9,12 @@ import AttributeDetails from '../malcolmWidgets/attributeDetails/attributeDetail
 import MethodDetails from '../malcolmWidgets/method/method.component';
 
 const ascii404 =
-  '             __   __    _____     __   __ \n' +
-  '            |\\  \\ |\\  \\  |\\   __  \\  |\\  \\  |\\  \\ \n' +
-  '            \\ \\  \\\\_\\  \\ \\ \\  \\|\\   \\ \\ \\  \\\\_\\  \\ \n' +
-  '             \\ \\___    \\ \\ \\  \\_\\  \\ \\ \\ ___   \\ \n' +
-  '              \\|___|\\__\\ \\ \\_____\\ \\|___|\\__\\ \n' +
-  '                     \\|__|  \\|_____|        \\|__| \n';
+  '              __     __      _____     __    __ \n' +
+  '             |\\  \\  |\\  \\   |\\   __  \\  |\\  \\  |\\  \\ \n' +
+  '             \\ \\  \\\\_\\  \\ \\ \\  \\|\\  \\ \\ \\  \\\\_\\  \\ \n' +
+  '               \\ \\___     \\ \\ \\  \\_\\  \\ \\ \\ ___   \\ \n' +
+  '                 \\|___|\\__\\ \\ \\_____\\ \\|___|\\__\\ \n' +
+  '                         \\|__|   \\|______|        \\|__| \n';
 
 const styles = theme => ({
   progressContainer: {
@@ -28,14 +28,20 @@ const styles = theme => ({
 
 const ignoredAttributes = ['widget:icon'];
 
-export const isBlockLoading = block => {
-  if (block !== undefined && block.loading === 404) {
-    return 404;
+export const isBlockLoading = (block, blockName, blockList) => {
+  if (blockList.length > 0) {
+    if (
+      (block !== undefined && block.loading === 404) ||
+      (block === undefined && !blockList.includes(blockName))
+    ) {
+      return 404;
+    }
+    return (
+      block !== undefined &&
+      (block.loading || block.attributes.some(a => a.loading))
+    );
   }
-  return (
-    block !== undefined &&
-    (block.loading || block.attributes.some(a => a.loading))
-  );
+  return true;
 };
 export const isRootLevelAttribute = a =>
   !a.calculated.inGroup &&
@@ -50,16 +56,17 @@ export const isRootLevelAttribute = a =>
   );
 export const areAttributesAvailable = block => block && block.attributes;
 
-const blockLoading = notFound =>
+const blockLoadingSpinner = notFound =>
   notFound ? (
     <div>
-      <div align="left" style={{ whiteSpace: 'pre' }}>
+      <div align="left" style={{ fontFamily: 'Roboto', whiteSpace: 'pre' }}>
         {ascii404}
       </div>
       <br />
       <br />
-      Block not found! <br />
-      (hint: URLs are case sensitive)
+      <Typography>Block not found....yet</Typography>
+      <Typography>it may still be loading and appear later</Typography>
+      <Typography>(hint: URLs are case sensitive)</Typography>
     </div>
   ) : (
     <div>
@@ -146,7 +153,7 @@ const displayAttributes = props => {
 const BlockDetails = props => (
   <div className={props.classes.progressContainer}>
     {props.blockLoading
-      ? blockLoading(props.blockLoading === 404)
+      ? blockLoadingSpinner(props.blockLoading === 404)
       : displayAttributes(props)}
   </div>
 );
@@ -181,6 +188,9 @@ GroupDivider.propTypes = {
 const mapStateToProps = (state, ownProps, memory) => {
   const stateMemory = memory;
   let block;
+  const blockList = state.malcolm.blocks['.blocks']
+    ? state.malcolm.blocks['.blocks'].children
+    : [];
   if (ownProps.parent) {
     block = state.malcolm.parentBlock
       ? state.malcolm.blocks[state.malcolm.parentBlock]
@@ -190,7 +200,11 @@ const mapStateToProps = (state, ownProps, memory) => {
       ? state.malcolm.blocks[state.malcolm.childBlock]
       : undefined;
   }
-
+  const blockLoading = isBlockLoading(
+    block,
+    ownProps.parent ? state.malcolm.parentBlock : state.malcolm.childBlock,
+    blockList
+  );
   if (
     block &&
     block.attributes &&
@@ -222,10 +236,9 @@ const mapStateToProps = (state, ownProps, memory) => {
 
     stateMemory.oldAttributes = block.attributes;
   }
-
   return {
     blockName: block ? block.name : '',
-    blockLoading: isBlockLoading(block),
+    blockLoading,
     attributesAvailable: areAttributesAvailable(block) !== undefined,
     rootAttributes: stateMemory.rootAttributes,
     groups: stateMemory.groups,

--- a/src/blockDetails/blockDetails.test.js
+++ b/src/blockDetails/blockDetails.test.js
@@ -21,7 +21,16 @@ describe('Block Details', () => {
         childBlock: 'test1',
         blocks: {
           test1: {},
+          '.blocks': {
+            children: ['test1'],
+          },
         },
+        navigation: {
+          navigationLists: [],
+        },
+      },
+      viewState: {
+        openParentPanel: true,
       },
     };
   });

--- a/src/malcolm/reducer/attribute.reducer.js
+++ b/src/malcolm/reducer/attribute.reducer.js
@@ -135,10 +135,14 @@ export const updateNavigation = (state, attributeName) => {
     ) > -1
   ) {
     navigation = processNavigationLists(
-      state.navigation.navigationLists.map(
-        nav =>
-          nav.subElements ? [nav.path, ...nav.subElements].join('.') : nav.path
-      ),
+      state.navigation.navigationLists.map(nav => {
+        if (nav.subElements && nav.subElements[0] !== undefined) {
+          return [nav.path, ...nav.subElements].join('.');
+        } else if (nav.badUrlPart) {
+          return [nav.path, ...nav.badUrlPart].join('.');
+        }
+        return nav.path;
+      }),
       state.blocks
     );
   }

--- a/src/malcolm/reducer/navigation.reducer.js
+++ b/src/malcolm/reducer/navigation.reducer.js
@@ -78,9 +78,8 @@ function updateNavTypes(state) {
     updatedState = { ...state };
 
     ({ navigationLists } = updatedState.navigation);
-    const navIndices = navigationLists.map((nav, index) => index);
-    navIndices.forEach((originalIndex, i) => {
-      const nav = navigationLists[originalIndex];
+    navigationLists.forEach((originalNav, i) => {
+      const nav = originalNav;
       if (nav.navType === undefined) {
         if (nav.path === '.info') {
           nav.navType = NavTypes.Info;
@@ -93,7 +92,7 @@ function updateNavTypes(state) {
         } else if (nav.path === '.palette') {
           nav.navType = NavTypes.Palette;
           nav.label = 'Palette';
-        } else if (originalIndex === 0 && isBlockMri(nav.path, state.blocks)) {
+        } else if (i === 0 && isBlockMri(nav.path, state.blocks)) {
           nav.navType = NavTypes.Block;
           nav.blockMri = nav.path;
           nav.label = nav.path;
@@ -133,15 +132,13 @@ function updateNavTypes(state) {
                 nav.badUrlPart = subElements;
                 nav.label = [nav.label, ...subElements].join('.');
                 if (
-                  navigationLists[originalIndex + 1] &&
-                  navigationLists[originalIndex + 1].path !== '.info'
+                  navigationLists[i + 1] &&
+                  navigationLists[i + 1].path !== '.info'
                 ) {
-                  navigationLists
-                    .slice(originalIndex + 1)
-                    .forEach(navElement => {
-                      const erroredNav = navElement;
-                      erroredNav.navType = NavTypes.Error;
-                    });
+                  navigationLists.slice(i + 1).forEach(navElement => {
+                    const erroredNav = navElement;
+                    erroredNav.navType = NavTypes.Error;
+                  });
                 }
               }
             }
@@ -169,20 +166,20 @@ function updateNavTypes(state) {
               nav.navType === undefined &&
               !matchingAttribute.calculated.loading
             ) {
-              navigationLists.slice(originalIndex).forEach(navElement => {
+              navigationLists.slice(i).forEach(navElement => {
                 const erroredNav = navElement;
                 erroredNav.navType = NavTypes.Error;
               });
             }
           }
         }
-        if (navigationLists[originalIndex - 1]) {
-          nav.parent = navigationLists[originalIndex - 1];
+        if (navigationLists[i - 1]) {
+          nav.parent = navigationLists[i - 1];
           if (
-            navigationLists[originalIndex - 1].children &&
-            navigationLists[originalIndex - 1].children.length > 0
+            navigationLists[i - 1].children &&
+            navigationLists[i - 1].children.length > 0
           ) {
-            // nav.siblings = navigationLists[originalIndex - 1].children;
+            // nav.siblings = navigationLists[i - 1].children;
           }
         }
       }

--- a/src/malcolm/reducer/navigation.reducer.js
+++ b/src/malcolm/reducer/navigation.reducer.js
@@ -132,7 +132,10 @@ function updateNavTypes(state) {
                 nav.subElements = [undefined];
                 nav.badUrlPart = subElements;
                 nav.label = [nav.label, ...subElements].join('.');
-                if (navigationLists[originalIndex + 1].path !== '.info') {
+                if (
+                  navigationLists[originalIndex + 1] &&
+                  navigationLists[originalIndex + 1].path !== '.info'
+                ) {
                   navigationLists
                     .slice(originalIndex + 1)
                     .forEach(navElement => {

--- a/src/navbar/__snapshots__/navcontrol.test.js.snap
+++ b/src/navbar/__snapshots__/navcontrol.test.js.snap
@@ -37,6 +37,7 @@ exports[`NavControl renders correctly 1`] = `
 >
   <WithStyles(Typography)
     className="NavControl-currentLink-2"
+    color="default"
     onClick={[Function]}
     variant="subheading"
   >

--- a/src/navbar/__snapshots__/navcontrol.test.js.snap
+++ b/src/navbar/__snapshots__/navcontrol.test.js.snap
@@ -89,6 +89,60 @@ exports[`NavControl renders correctly for final 1`] = `
 </div>
 `;
 
+exports[`NavControl renders correctly when nav element is errored and has no siblings 1`] = `
+<div
+  className="NavControl-container-1"
+>
+  <WithStyles(Typography)
+    className="NavControl-currentLink-2"
+    color="error"
+    onClick={[Function]}
+    variant="subheading"
+  >
+    NotPANDA
+  </WithStyles(Typography)>
+  <Component
+    anchorEl={null}
+    handleClick={[Function]}
+    handleClose={[Function]}
+    icon={<pure(KeyboardArrowDownIcon) />}
+    navigateToChild={[Function]}
+  />
+</div>
+`;
+
+exports[`NavControl renders correctly when nav element is errored but has valid siblings 1`] = `
+<div
+  className="NavControl-container-1"
+>
+  <WithStyles(Typography)
+    className="NavControl-currentLink-2"
+    color="error"
+    onClick={[Function]}
+    variant="subheading"
+  >
+    NotPANDA
+  </WithStyles(Typography)>
+  <Component
+    anchorEl={null}
+    childElementLabels={
+      Array [
+        "PANDA",
+      ]
+    }
+    childElements={
+      Array [
+        "PANDA:mri",
+      ]
+    }
+    handleClick={[Function]}
+    handleClose={[Function]}
+    icon={<pure(KeyboardArrowDownIcon) />}
+    navigateToChild={[Function]}
+  />
+</div>
+`;
+
 exports[`NavControl selector component renders correctly 1`] = `
 <div
   style={

--- a/src/navbar/navcontrol.component.js
+++ b/src/navbar/navcontrol.component.js
@@ -61,6 +61,12 @@ class NavControl extends Component {
       <div className={classes.container}>
         <Typography
           className={classes.currentLink}
+          color={
+            (siblingLabels && siblingLabels.includes(nav.label)) ||
+            ['Info', 'Palette'].includes(nav.label)
+              ? 'default'
+              : 'error'
+          }
           variant="subheading"
           onClick={() => navigateToChild(nav.path)}
         >

--- a/src/navbar/navcontrol.test.js
+++ b/src/navbar/navcontrol.test.js
@@ -126,4 +126,22 @@ describe('NavControl', () => {
     ).toBeNull();
     expect(navigateFunction.mock.calls.length).toEqual(1);
   });
+
+  it('renders correctly when nav element is errored but has valid siblings', () => {
+    nav.label = 'NotPANDA';
+    const wrapper = shallow(
+      <NavControl nav={nav} navigateToChild={() => {}} />
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
+  it('renders correctly when nav element is errored and has no siblings', () => {
+    nav.label = 'NotPANDA';
+    nav.parent.children = undefined;
+    nav.parent.childrenLabels = undefined;
+    const wrapper = shallow(
+      <NavControl nav={nav} navigateToChild={() => {}} />
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Description

Improved error handling and displaying when attempting to load invalid URLs

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/PANDA:SEQ5 and check that the block not found error displays
- navigate to localhost:3000/gui/PANDA/layout/SEQ5/layout/SEQ1 and check that everything in the nav bar after PANDA/layout is shown as errored and that the PANDA layout displays in the middle pane.
- navigate to localhost:3000/PANDA:SEQ1/table.row.100/.info and check that the table loads but "Table.row.100" displays in red in the nav bar and the info pane is empty.

## Agile board tracking

connect to #380 
closes #380