### PR TITLE
Attribute highlight fix

### DIFF
--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -181,6 +181,7 @@ const mapStateToProps = (state, ownProps) => {
     isMainAttribute:
       attribute &&
       attribute.calculated &&
+      ownProps.blockName === state.malcolm.parentBlock &&
       state.malcolm.mainAttribute === attribute.calculated.name,
   };
 };


### PR DESCRIPTION


## Description
Fixed attribute in child pane highlighting if name matches main attribute name

## Testing instructions
Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm run ui-only
- connect to a malcolm instance which has multiple blocks with layouts
- view the top level layout and open a child block which has its own layout
- check that the layout attribute in the child pane isn't highlighted

## Agile board tracking
connect to #379 
closes #379