### PR TITLE
Fixed duplicate subscription bug

### DIFF
--- a/server/test-malcolm-server.js
+++ b/server/test-malcolm-server.js
@@ -21,7 +21,7 @@ io.on('connection', function (socket) {
       console.log(error);
     }
   });
-  socket.on('disconnect', () => handleDisconnect());
+  socket.on('close', () => handleDisconnect());
   socket.on('error', (err) => {
     subscriptionFeed.cancelAllSubscriptions();
     subscriptions = [];

--- a/server/test-malcolm-server.js
+++ b/server/test-malcolm-server.js
@@ -117,6 +117,7 @@ function handleMessage(socket, message) {
     if (simplifiedMessage.typeid.indexOf('Subscribe') > -1) {
       if (Object.keys(subscribedPaths).some(path => subscribedPaths[path] === originalId.toString())) {
         response = buildErrorMessage(originalId, 'duplicate subscription ID on client')
+        console.log(`duplicate subscription ID on client (id=${originalId})`)
       } else {
         subscriptions.push(originalId.toString());
         subscribedPaths[JSON.stringify(simplifiedMessage.path)] = originalId.toString();

--- a/server/test-malcolm-server.js
+++ b/server/test-malcolm-server.js
@@ -115,10 +115,13 @@ function handleMessage(socket, message) {
     let response = Object.assign({id: originalId}, pathIndexedMessages[JSON.stringify(simplifiedMessage.path)]);
 
     if (simplifiedMessage.typeid.indexOf('Subscribe') > -1) {
-      subscriptions.push(originalId.toString());
-      subscribedPaths[JSON.stringify(simplifiedMessage.path)] = originalId.toString();
-
-      response = subscriptionFeed.checkForActiveSubscription(simplifiedMessage, response, socket);
+      if (Object.keys(subscribedPaths).some(path => subscribedPaths[path] === originalId.toString())) {
+        response = buildErrorMessage(originalId, 'duplicate subscription ID on client')
+      } else {
+        subscriptions.push(originalId.toString());
+        subscribedPaths[JSON.stringify(simplifiedMessage.path)] = originalId.toString();
+        response = subscriptionFeed.checkForActiveSubscription(simplifiedMessage, response, socket);
+      }
     }
 
     sendResponse(socket, response);

--- a/src/malcolm/malcolm.types.js
+++ b/src/malcolm/malcolm.types.js
@@ -31,3 +31,4 @@ export const MalcolmArchiveMethodRun = 'malcolm:archivemethod';
 export const MalcolmTickArchive = 'malcolm:tickarchiveattribute';
 export const MalcolmRunAutoLayoutType = 'malcolm:runautolayout';
 export const MalcolmSimpleLocalState = 'malcolm:simplelocalstate';
+export const MalcolmIncrementMessageCount = 'malcolm:incrementcounter';

--- a/src/malcolm/malcolmActionCreators.js
+++ b/src/malcolm/malcolmActionCreators.js
@@ -95,13 +95,12 @@ export const malcolmResetBlocks = () => (dispatch, getState) => {
 
   const state = getState();
   state.malcolm.messagesInFlight = {};
-  Object.values(state.malcolm.blocks).forEach(block => {
-    dispatch(
-      malcolmSubscribeAction(
-        block.name === '.blocks' ? ['.', 'blocks'] : [block.name, 'meta']
-      )
-    );
-  });
+  dispatch(malcolmSubscribeAction(['.', 'blocks'], false));
+  Object.values(state.malcolm.blocks)
+    .filter(block => block.name !== '.blocks')
+    .forEach(block => {
+      dispatch(malcolmSubscribeAction([block.name, 'meta']));
+    });
 };
 
 export const malcolmSetDisconnected = () => ({

--- a/src/malcolm/malcolmSocket.js
+++ b/src/malcolm/malcolmSocket.js
@@ -31,6 +31,9 @@ class MalcolmSocketContainer {
     }
     return 0;
   }
+  purge() {
+    this.queue = [];
+  }
 }
 
 export default MalcolmSocketContainer;

--- a/src/malcolm/malcolmSocketHandler.test.js
+++ b/src/malcolm/malcolmSocketHandler.test.js
@@ -186,15 +186,17 @@ describe('malcolm socket handler', () => {
 
   it('resets blocks on open or reconnect', () => {
     malcolmWorker.postMessage('socket connected');
-    expect(dispatches.length).toEqual(4);
+    expect(dispatches.length).toEqual(5);
     expect(dispatches[0].type).toEqual(MalcolmCleanBlocks);
-    expect(dispatches[3].type).toEqual(snackbar);
-    expect(dispatches[3].snackbar.open).toEqual(true);
-    expect(dispatches[3].snackbar.message).toEqual(`Connected to WebSocket`);
-    expect(dispatches[1].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
-    expect(dispatches[1].payload.path).toEqual(['Test:TestBlock', 'meta']);
+    expect(dispatches[4].type).toEqual(snackbar);
+    expect(dispatches[4].snackbar.open).toEqual(true);
+    expect(dispatches[4].snackbar.message).toEqual(`Connected to WebSocket`);
+    expect(dispatches[3].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
+    expect(dispatches[3].payload.path).toEqual(['Test:TestBlock2', 'meta']);
     expect(dispatches[2].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
-    expect(dispatches[2].payload.path).toEqual(['Test:TestBlock2', 'meta']);
+    expect(dispatches[2].payload.path).toEqual(['Test:TestBlock', 'meta']);
+    expect(dispatches[1].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
+    expect(dispatches[1].payload.path).toEqual(['.', 'blocks']);
   });
 
   it('does nothing on receiving a non-malcolm message', () => {

--- a/src/malcolm/middleware/malcolmReduxMiddleware.js
+++ b/src/malcolm/middleware/malcolmReduxMiddleware.js
@@ -1,4 +1,4 @@
-import { MalcolmSend } from '../malcolm.types';
+import { MalcolmIncrementMessageCount, MalcolmSend } from '../malcolm.types';
 import handleLocationChange from './malcolmRouting';
 
 function sendMalcolmMessage(worker, payload) {
@@ -7,16 +7,6 @@ function sendMalcolmMessage(worker, payload) {
   const msg = JSON.stringify(message);
 
   worker.postMessage(msg);
-}
-
-function getNextId(malcolmState) {
-  const copiedState = malcolmState;
-  if (copiedState.counter) {
-    copiedState.counter += 1;
-  } else {
-    copiedState.counter = 1;
-  }
-  return copiedState.counter;
 }
 
 function subscriptionActive(path, messagesInFlight) {
@@ -34,7 +24,8 @@ const buildMalcolmReduxMiddleware = worker => store => next => action => {
 
   switch (action.type) {
     case MalcolmSend:
-      updatedAction.payload.id = getNextId(store.getState().malcolm);
+      store.dispatch({ type: MalcolmIncrementMessageCount });
+      updatedAction.payload.id = store.getState().malcolm.counter;
 
       if (
         action.payload.typeid !== 'malcolm:core/Subscribe:1.0' ||

--- a/src/malcolm/middleware/malcolmReduxMiddleware.test.js
+++ b/src/malcolm/middleware/malcolmReduxMiddleware.test.js
@@ -3,6 +3,7 @@ import {
   MalcolmNewBlock,
   MalcolmSend,
   MalcolmNavigationPathUpdate,
+  MalcolmIncrementMessageCount,
 } from '../malcolm.types';
 
 describe('malcolm redux middleware', () => {
@@ -42,7 +43,13 @@ describe('malcolm redux middleware', () => {
     };
     store = {
       getState: () => ({ malcolm: malcolmState }),
-      dispatch: action => dispatches.push(action),
+      dispatch: action => {
+        dispatches.push(action);
+        malcolmState.counter =
+          action.type === MalcolmIncrementMessageCount
+            ? malcolmState.counter + 1
+            : malcolmState.counter;
+      },
     };
   });
 

--- a/src/malcolm/reducer/malcolmReducer.js
+++ b/src/malcolm/reducer/malcolmReducer.js
@@ -4,6 +4,7 @@ import {
   MalcolmUpdateBlockPosition,
   MalcolmShiftButton,
   MalcolmSelectPortType,
+  MalcolmIncrementMessageCount,
 } from '../malcolm.types';
 import blockUtils from '../blockUtils';
 import { AlarmStates } from '../../malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component';
@@ -52,6 +53,12 @@ const initialMalcolmState = {
     inDeleteZone: false,
   },
 };
+
+function incrementCounter(state) {
+  const updatedState = state;
+  updatedState.counter += 1;
+  return updatedState;
+}
 
 function setFlag(state, path, flagType, flagState) {
   if (path.length === 1) {
@@ -135,6 +142,8 @@ const malcolmReducer = (state = initialMalcolmState, action = {}) => {
   updatedState = SocketReducer(updatedState, action);
 
   switch (action.type) {
+    case MalcolmIncrementMessageCount:
+      return incrementCounter(state);
     case MalcolmAttributeFlag:
       return setFlag(
         state,

--- a/src/malcolm/reducer/socket.reducer.js
+++ b/src/malcolm/reducer/socket.reducer.js
@@ -98,7 +98,6 @@ export function setDisconnected(state) {
   return {
     ...state,
     blocks,
-    counter: 0,
   };
 }
 

--- a/src/malcolm/worker/malcolm.worker.js
+++ b/src/malcolm/worker/malcolm.worker.js
@@ -8,8 +8,8 @@ const webSocket = new MalcolmReconnector('', 5000, WebSocket);
 const socketContainer = new MalcolmSocketContainer(webSocket);
 console.log('connecting to worker socket');
 
-const messagesInFlight = {};
-const existingAttributes = {};
+let messagesInFlight = {};
+let existingAttributes = {};
 
 let bufferedMessages = [];
 
@@ -57,6 +57,9 @@ socketContainer.socket.onmessage = event => {
 
 socketContainer.socket.onclose = () => {
   flushBuffer();
+  socketContainer.purge();
+  messagesInFlight = {};
+  existingAttributes = {};
   console.log('socket disconnected');
   self.postMessage('socket disconnected');
 };

--- a/src/middlePanelViews/attributeView/archiveTable.container.js
+++ b/src/middlePanelViews/attributeView/archiveTable.container.js
@@ -68,6 +68,7 @@ class ArchiveTable extends React.Component {
         addRow={noOp}
         infoClickHandler={noOp}
         rowClickHandler={noOp}
+        closePanelHandler={noOp}
       />
     );
   }


### PR DESCRIPTION
## Description

Message send queue now discarded on disconnect. Disconnect also no longer resets message counter to 0.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm run ui-only
- navigate to localhost:3000/gui/PANDA/layout
- wait til the page displays a snackbar saying "websocket disconnected"
- npm run server in a separate terminal
- Check that the page loads correctly and no errors are displayed in the client

## Agile board tracking

connect to #380 
closes #380 