### PR TITLE
Bugfix/layout loading #389

### DIFF
--- a/src/malcolm/actions/navigation.actions.js
+++ b/src/malcolm/actions/navigation.actions.js
@@ -32,6 +32,27 @@ const subscribeToNewBlocksInRoute = () => (dispatch, getState) => {
   });
 };
 
+const subscribeToChildren = () => (dispatch, getState) => {
+  const state = getState().malcolm;
+  const { navigationLists } = state.navigation;
+
+  const lastNav = navigationLists.slice(-1)[0];
+  if (lastNav.navType === NavTypes.Attribute) {
+    const attribute = blockUtils.findAttribute(
+      state.blocks,
+      lastNav.parent.blockMri,
+      lastNav.path
+    );
+    attribute.raw.value.visible.forEach((visible, i) => {
+      const child = attribute.raw.value.mri[i];
+      if (visible && !state.blocks[child]) {
+        dispatch(malcolmNewBlockAction(child, false, false));
+        dispatch(malcolmSubscribeAction([child, 'meta']));
+      }
+    });
+  }
+};
+
 const navigateToAttribute = (blockMri, attributeName) => (
   dispatch,
   getState
@@ -273,6 +294,7 @@ const closeInfo = (blockMri, attributeName, subElement) => (
 };
 
 export default {
+  subscribeToChildren,
   subscribeToNewBlocksInRoute,
   navigateToAttribute,
   navigateToInfo,

--- a/src/navbar/navbar.component.js
+++ b/src/navbar/navbar.component.js
@@ -11,6 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import MenuIcon from '@material-ui/icons/Menu';
 import { openParentPanel } from '../viewState/viewState.actions';
 import NavControl from './navcontrol.component';
+import navigationActions from '../malcolm/actions/navigation.actions';
 
 const drawerWidth = 320;
 
@@ -134,8 +135,10 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => ({
   openParent: () => dispatch(openParentPanel(true)),
-  navigateToChild: (basePath, child) =>
-    dispatch(push(`/gui${basePath}${child}`)),
+  navigateToChild: (basePath, child) => {
+    dispatch(push(`/gui${basePath}${child}`));
+    dispatch(navigationActions.subscribeToChildren());
+  },
 });
 
 NavBar.propTypes = {

--- a/src/navbar/navbar.test.js
+++ b/src/navbar/navbar.test.js
@@ -1,10 +1,17 @@
 import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
-import configureStore from 'redux-mock-store';
 import NavBar from './navbar.component';
 import { openParentPanelType } from '../viewState/viewState.actions';
 
-const mockStore = configureStore();
+const mockStore = state => {
+  const actions = [];
+  return {
+    getState: () => state,
+    dispatch: action => actions.push(action),
+    subscribe: () => {},
+    getActions: () => actions,
+  };
+};
 
 describe('NavBar', () => {
   let shallow;
@@ -114,7 +121,7 @@ describe('NavBar', () => {
       .simulate('click');
 
     const actions = store.getActions();
-    expect(actions.length).toEqual(1);
+    expect(actions.length).toEqual(2);
     expect(actions[0].type).toBe('@@router/CALL_HISTORY_METHOD');
     expect(actions[0].payload.args).toEqual(['/gui/PANDA:SEQ1']);
   });
@@ -135,7 +142,7 @@ describe('NavBar', () => {
       .simulate('click');
 
     const actions = store.getActions();
-    expect(actions.length).toEqual(1);
+    expect(actions.length).toEqual(2);
     expect(actions[0].type).toBe('@@router/CALL_HISTORY_METHOD');
     expect(actions[0].payload.args).toEqual(['/gui/PANDA/layout']);
   });
@@ -156,7 +163,7 @@ describe('NavBar', () => {
       .simulate('click');
 
     const actions = store.getActions();
-    expect(actions.length).toEqual(1);
+    expect(actions.length).toEqual(2);
     expect(actions[0].type).toBe('@@router/CALL_HISTORY_METHOD');
     expect(actions[0].payload.args).toEqual(['/gui/PANDA/layout/SEQ1/Val']);
   });

--- a/src/navbar/navbar.test.js
+++ b/src/navbar/navbar.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import NavBar from './navbar.component';
 import { openParentPanelType } from '../viewState/viewState.actions';
+import navigationActions from '../malcolm/actions/navigation.actions';
 
 const mockStore = state => {
   const actions = [];
@@ -124,6 +125,11 @@ describe('NavBar', () => {
     expect(actions.length).toEqual(2);
     expect(actions[0].type).toBe('@@router/CALL_HISTORY_METHOD');
     expect(actions[0].payload.args).toEqual(['/gui/PANDA:SEQ1']);
+    expect(actions[1]).toBeInstanceOf(Function);
+    const thunkResult = actions[1](store.dispatch, store.getState);
+    expect(thunkResult).toEqual(
+      navigationActions.subscribeToChildren()(store.dispatch, store.getState)
+    );
   });
 
   it('navigating to nav item changes the route', () => {
@@ -145,6 +151,11 @@ describe('NavBar', () => {
     expect(actions.length).toEqual(2);
     expect(actions[0].type).toBe('@@router/CALL_HISTORY_METHOD');
     expect(actions[0].payload.args).toEqual(['/gui/PANDA/layout']);
+    expect(actions[1]).toBeInstanceOf(Function);
+    const thunkResult = actions[1](store.dispatch, store.getState);
+    expect(thunkResult).toEqual(
+      navigationActions.subscribeToChildren()(store.dispatch, store.getState)
+    );
   });
 
   it('navigating to new root item changes the route', () => {
@@ -166,5 +177,10 @@ describe('NavBar', () => {
     expect(actions.length).toEqual(2);
     expect(actions[0].type).toBe('@@router/CALL_HISTORY_METHOD');
     expect(actions[0].payload.args).toEqual(['/gui/PANDA/layout/SEQ1/Val']);
+    expect(actions[1]).toBeInstanceOf(Function);
+    const thunkResult = actions[1](store.dispatch, store.getState);
+    expect(thunkResult).toEqual(
+      navigationActions.subscribeToChildren()(store.dispatch, store.getState)
+    );
   });
 });


### PR DESCRIPTION
## Description

Fixed navbar so navigating to new widget:flowgraph attribute triggers subscription to its visible children 

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/
- select PANDA as the root block in the nav bar
- once PANDA loads, select layout from the nav bar
- check that the layout and all the visible blocks load correctly

## Agile board tracking

connect to #389 
closes #389