### PR TITLE
Feature/combobox behaviour #312

### DIFF
--- a/cypress/automated_screenshots/user_guide_screenshots.js
+++ b/cypress/automated_screenshots/user_guide_screenshots.js
@@ -56,4 +56,16 @@ describe('User guide screenshots', () => {
     cy.wait(1000);
     cy.screenshot('PANDA-new-link');
   });
+
+  it('attribute viewer', () => {
+    cy.visit('/gui/PANDA:INENC1/val');
+    cy.waitForDetailsToLoad();
+    cy.waitForSnackbarToDisappear();
+    cy.wait(30000); // wait for attribute plot to collect enough data
+    cy.screenshot('Attribute-Table');
+
+    cy.get('[data-cy=plotTab]').click();
+    cy.waitForComponentToLoad();
+    cy.screenshot('Attribute-Plot');
+  });
 });

--- a/cypress/automated_screenshots/user_guide_screenshots.js
+++ b/cypress/automated_screenshots/user_guide_screenshots.js
@@ -67,5 +67,8 @@ describe('User guide screenshots', () => {
     cy.get('[data-cy=plotTab]').click();
     cy.waitForComponentToLoad();
     cy.screenshot('Attribute-Plot');
+
+    cy.get('[]').trigger('mouseover');
+    cy.screenshot('Plot-toolbar');
   });
 });

--- a/cypress/integration/child_panel_state_spec.js
+++ b/cypress/integration/child_panel_state_spec.js
@@ -7,13 +7,13 @@ describe('Child panel', () => {
       cy.visit('/gui/PANDA/layout');
       cy.waitForDetailsToLoad();
 
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('should open when a block is clicked in the layout', () => {
       // click on the block to open the child panel
       cy.contains('TTL output 1').click('left');
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
 
       // check that a property of TTL output 1 is visible in the details panel
       cy.contains('Val Current').should('be.visible');
@@ -22,24 +22,24 @@ describe('Child panel', () => {
     it('should update child panel if already open', () => {
       // first make sure the child panel is open
       cy.contains('TTL output 1').click('left');
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
 
       // click on another block and make sure the details update
       cy.contains('Input encoder 1').click('left');
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       cy.contains('Clk Period').should('be.visible');
     });
 
     it('should not open the child panel if a block was dragged', () => {
       cy.moveBlock('TTL output 1', { x: 450, y: 280 });
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('should close the palette when a block is dropped on to the layout', () => {
       cy.contains('TTL output 1').should('be.visible');
 
       cy.get('[data-cy=palettebutton]').click('left');
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       cy
         .get(childPanel)
         .parent()
@@ -54,7 +54,7 @@ describe('Child panel', () => {
         clientY: 180,
       });
 
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('should open the child panel when a link is clicked on', () => {
@@ -66,19 +66,19 @@ describe('Child panel', () => {
         .first()
         .click({ force: true });
 
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       cy.contains('Sink').should('be.visible');
     });
 
     it('should close the child panel when the layout background is clicked', () => {
       cy.visit('/gui/PANDA/layout/TTLOUT1');
       cy.waitForDetailsToLoad();
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       cy.contains('Val Current').should('be.visible'); // wait for details to load
 
       // click in an empty part of the layout
       cy.get('#LayoutDiv').click(450, 180);
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('multi-selecting blocks closes child panel', () => {
@@ -86,13 +86,13 @@ describe('Child panel', () => {
       cy.wait(3000, { log: false });
 
       cy.contains('ADDER1').click('left');
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       cy
         .get('body')
         .type('{shift}', { release: false })
         .contains('BITS')
         .click();
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
   });
 
@@ -107,7 +107,7 @@ describe('Child panel', () => {
         .parent()
         .find('button')
         .click();
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
 
       // confirm info element is present
       cy.contains('Type ID').should('be.visible');
@@ -126,7 +126,7 @@ describe('Child panel', () => {
         .click()
         .click();
 
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('clicking on row alarm should open panel', () => {
@@ -136,10 +136,10 @@ describe('Child panel', () => {
         .find('button')
         .first()
         .click();
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
 
       // confirm info element is present
-      cy.contains('Row local state').should('be.visible');
+      cy.contains('Row remote state').should('be.visible');
     });
 
     it('clicking the table background should close the info panel', () => {
@@ -149,12 +149,12 @@ describe('Child panel', () => {
         .find('button')
         .first()
         .click();
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
 
       // click in the background area
       cy.get('[data-cy=table]').click(100, 400);
 
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('clicking a row control should not open child panel if not already open', () => {
@@ -163,7 +163,7 @@ describe('Child panel', () => {
         .find('input')
         .first()
         .click();
-      cy.get(childPanel).should('not.be.visible');
+      cy.checkFor(childPanel, false);
     });
 
     it('clicking a row control should update child panel if already open', () => {
@@ -172,7 +172,7 @@ describe('Child panel', () => {
         .find('button')
         .first()
         .click();
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       // ensure info for row 0
       cy.get('p:contains(0)').should('have.length', 2);
 
@@ -181,7 +181,7 @@ describe('Child panel', () => {
         .find('input')
         .last()
         .click({ force: true });
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
       // ensure info for row 1
       cy.wait(2000, { log: false });
       cy.get('p:contains(1)').should('have.length', 2);
@@ -193,7 +193,7 @@ describe('Child panel', () => {
         .get('[data-cy=table]')
         .contains('source')
         .click();
-      cy.get(childPanel).should('be.visible');
+      cy.checkFor(childPanel);
     });
   });
 });

--- a/cypress/integration/malcolmjs_spec.js
+++ b/cypress/integration/malcolmjs_spec.js
@@ -1,6 +1,8 @@
 describe('MalcolmJS', () => {
   it('.should() - load correctly', () => {
+    cy.request('/reset');
     cy.visit('/gui/');
     cy.title().should('equal', 'MalcolmJS DEV');
+    cy.request('/reset');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -49,6 +49,11 @@ Cypress.Commands.add('waitForSnackbarToDisappear', () => {
     .should('have.length', 0);
 });
 
+Cypress.Commands.add('checkFor', (element, state = true) => {
+  cy.wait(1000);
+  cy.get(element).should(`${state ? '' : 'not.'}be.visible`);
+});
+
 Cypress.Commands.add('waitForComponentToLoad', () => {
   cy.log('Waiting for component to load');
   cy.wait(1000, { log: false });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -49,6 +49,14 @@ Cypress.Commands.add('waitForSnackbarToDisappear', () => {
     .should('have.length', 0);
 });
 
+Cypress.Commands.add('waitForComponentToLoad', () => {
+  cy.log('Waiting for component to load');
+  cy.wait(1000, { log: false });
+  cy
+    .contains('Loading', { timeout: 5000, log: false })
+    .should('have.length', 0);
+});
+
 Cypress.Commands.add('waitForDetailsToLoad', () => {
   cy.log('waiting for details to load');
   cy.contains('Health', { log: false });

--- a/server/test-malcolm-server.js
+++ b/server/test-malcolm-server.js
@@ -9,7 +9,7 @@ let pathIndexedMessages = dataLoader.loadDatabyPath('./server/canned_data/');
 let subscriptions = [];
 let subscribedPaths = {};
 
-const port = 8000
+const port = 8000;
 const io = new WebSocket.Server({port});
 
 io.on('connection', function (socket) {
@@ -36,8 +36,7 @@ console.log('listening on port ', port);
 
 function resetServer() {
   pathIndexedMessages = dataLoader.loadDatabyPath('./server/canned_data/');
-  subscriptions = [];
-  subscribedPaths = {};
+  handleDisconnect();
 }
 
 function handleMessage(socket, message) {

--- a/src/drawerContainer/__snapshots__/drawerContainer.test.js.snap
+++ b/src/drawerContainer/__snapshots__/drawerContainer.test.js.snap
@@ -68,5 +68,180 @@ exports[`DrawerContainer renders correctly 1`] = `
       </div>
     </div>
   </WithStyles(Drawer)>
+  <div>
+    <WithStyles(Drawer)
+      PaperProps={
+        Object {
+          "style": Object {
+            "height": "calc(100vh - 10px)",
+          },
+        }
+      }
+      SlideProps={
+        Object {
+          "direction": "left",
+        }
+      }
+      anchor="left"
+      classes={
+        Object {
+          "paper": "DrawerContainer-drawer-1",
+        }
+      }
+      open={false}
+      transitionDuration={0}
+      variant="persistent"
+    >
+      <div
+        className="DrawerContainer-drawerContents-2"
+      >
+        <DrawerHeader
+          closeAction={[Function]}
+          popOutAction={[Function]}
+          title="Child"
+        />
+        <div>
+          Right
+        </div>
+      </div>
+    </WithStyles(Drawer)>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fafafa",
+          "minHeight": "100vh",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transition": "width 150ms",
+          "width": 0,
+          "zIndex": 9999,
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
+exports[`DrawerContainer renders correctly with panel transition 1`] = `
+<div>
+  <div>
+    <WithStyles(Connect(NavBar)) />
+    <div>
+      Middle
+    </div>
+  </div>
+  <WithStyles(Drawer)
+    PaperProps={
+      Object {
+        "style": Object {
+          "height": "calc(100vh - 10px)",
+        },
+      }
+    }
+    anchor="left"
+    classes={
+      Object {
+        "paper": "DrawerContainer-drawer-1",
+      }
+    }
+    open={true}
+    variant="persistent"
+  >
+    <div
+      className="DrawerContainer-drawerContents-2"
+    >
+      <DrawerHeader
+        closeAction={[Function]}
+        popOutAction={[Function]}
+        title="Parent"
+      />
+      <div>
+        Left
+      </div>
+    </div>
+  </WithStyles(Drawer)>
+  <WithStyles(Drawer)
+    PaperProps={
+      Object {
+        "style": Object {
+          "height": "calc(100vh - 10px)",
+        },
+      }
+    }
+    anchor="right"
+    classes={
+      Object {
+        "paper": "DrawerContainer-drawer-1",
+      }
+    }
+    open={true}
+    variant="persistent"
+  >
+    <div
+      className="DrawerContainer-drawerContents-2"
+    >
+      <DrawerHeader
+        closeAction={[Function]}
+        popOutAction={[Function]}
+        title="Child"
+      />
+      <div>
+        Right
+      </div>
+    </div>
+  </WithStyles(Drawer)>
+  <div>
+    <WithStyles(Drawer)
+      PaperProps={
+        Object {
+          "style": Object {
+            "height": "calc(100vh - 10px)",
+          },
+        }
+      }
+      SlideProps={
+        Object {
+          "direction": "left",
+        }
+      }
+      anchor="left"
+      classes={
+        Object {
+          "paper": "DrawerContainer-drawer-1",
+        }
+      }
+      open={true}
+      transitionDuration={500}
+      variant="persistent"
+    >
+      <div
+        className="DrawerContainer-drawerContents-2"
+      >
+        <DrawerHeader
+          closeAction={[Function]}
+          popOutAction={[Function]}
+          title="Child"
+        />
+        <div>
+          Right
+        </div>
+      </div>
+    </WithStyles(Drawer)>
+    <div
+      style={
+        Object {
+          "backgroundColor": "#fafafa",
+          "minHeight": "100vh",
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+          "transition": "width 500ms",
+          "width": "calc(100vw - 360px)",
+          "zIndex": 9999,
+        }
+      }
+    />
+  </div>
 </div>
 `;

--- a/src/drawerContainer/drawerContainer.component.js
+++ b/src/drawerContainer/drawerContainer.component.js
@@ -82,47 +82,54 @@ const DrawerContainer = props => (
         {props.children[props.children.length - 1]}
       </div>
     </Drawer>
-    <Drawer
-      variant="persistent"
-      open={props.transitionParent}
-      anchor="left"
-      SlideProps={{ direction: 'left' }}
-      transitionDuration={props.transitionParent ? 500 : 1}
-      classes={{ paper: props.classes.drawer }}
-      PaperProps={{
-        style: {
-          height: `calc(100vh - ${props.footerHeight}px)`,
-        },
-      }}
-    >
-      <div className={props.classes.drawerContents}>
-        <DrawerHeader
-          closeAction={() => props.closeChild(props.urlPath)}
-          title={props.childTitle}
-          popOutAction={() =>
-            props.popOutAction(
-              baseUrl,
-              drawerWidth,
-              props.childIsInfo
-                ? `${props.parentMRI}/${props.mainAttribute}/${props.childMRI}`
-                : props.childMRI
-            )
-          }
+    {!props.childIsInfo && !props.childIsPalette ? (
+      <div>
+        <Drawer
+          variant="persistent"
+          open={props.transitionParent}
+          anchor="left"
+          SlideProps={{ direction: 'left' }}
+          transitionDuration={props.transitionParent ? 500 : 0}
+          classes={{ paper: props.classes.drawer }}
+          PaperProps={{
+            style: {
+              height: `calc(100vh - ${props.footerHeight}px)`,
+            },
+          }}
+        >
+          <div className={props.classes.drawerContents}>
+            <DrawerHeader
+              closeAction={() => props.closeChild(props.urlPath)}
+              title={props.childTitle}
+              popOutAction={() =>
+                props.popOutAction(
+                  baseUrl,
+                  drawerWidth,
+                  props.childIsInfo
+                    ? `${props.parentMRI}/${props.mainAttribute}/${
+                        props.childMRI
+                      }`
+                    : props.childMRI
+                )
+              }
+            />
+            {props.children[props.children.length - 1]}
+          </div>
+        </Drawer>
+        <div
+          style={{
+            minHeight: '100vh',
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            width: props.transitionParent ? 'calc(100vw - 360px)' : 0,
+            transition: `width ${props.transitionParent ? '500' : '150'}ms`,
+            backgroundColor: props.theme.palette.background.default,
+            zIndex: 9999,
+          }}
         />
-        {props.children[props.children.length - 1]}
       </div>
-    </Drawer>
-    <div
-      style={{
-        minHeight: '100vh',
-        position: 'absolute',
-        right: 0,
-        top: 0,
-        width: props.transitionParent ? '100vw' : 0,
-        transition: 'width 500ms',
-        backgroundColor: props.theme.palette.background.default,
-      }}
-    />
+    ) : null}
   </div>
 );
 
@@ -133,9 +140,11 @@ const mapStateToProps = state => {
   );
   const navType = matchingNavItem ? matchingNavItem.navType : undefined;
   const childIsInfo = navType === NavTypes.Info;
+  const childIsPalette = navType === NavTypes.Palette;
 
   return {
     childIsInfo,
+    childIsPalette,
     mainAttribute: state.malcolm.mainAttribute,
     open: state.viewState.openParentPanel,
     openSecondary: state.malcolm.childBlock !== undefined,
@@ -167,6 +176,7 @@ DrawerContainer.propTypes = {
   }).isRequired,
   children: PropTypes.node,
   childIsInfo: PropTypes.bool.isRequired,
+  childIsPalette: PropTypes.bool.isRequired,
   mainAttribute: PropTypes.string.isRequired,
   footerHeight: PropTypes.number.isRequired,
   transitionParent: PropTypes.bool.isRequired,

--- a/src/drawerContainer/drawerContainer.component.js
+++ b/src/drawerContainer/drawerContainer.component.js
@@ -82,6 +82,47 @@ const DrawerContainer = props => (
         {props.children[props.children.length - 1]}
       </div>
     </Drawer>
+    <Drawer
+      variant="persistent"
+      open={props.transitionParent}
+      anchor="left"
+      SlideProps={{ direction: 'left' }}
+      transitionDuration={props.transitionParent ? 500 : 1}
+      classes={{ paper: props.classes.drawer }}
+      PaperProps={{
+        style: {
+          height: `calc(100vh - ${props.footerHeight}px)`,
+        },
+      }}
+    >
+      <div className={props.classes.drawerContents}>
+        <DrawerHeader
+          closeAction={() => props.closeChild(props.urlPath)}
+          title={props.childTitle}
+          popOutAction={() =>
+            props.popOutAction(
+              baseUrl,
+              drawerWidth,
+              props.childIsInfo
+                ? `${props.parentMRI}/${props.mainAttribute}/${props.childMRI}`
+                : props.childMRI
+            )
+          }
+        />
+        {props.children[props.children.length - 1]}
+      </div>
+    </Drawer>
+    <div
+      style={{
+        minHeight: '100vh',
+        position: 'absolute',
+        right: 0,
+        top: 0,
+        width: props.transitionParent ? '100vw' : 0,
+        transition: 'width 500ms',
+        backgroundColor: props.theme.palette.background.default,
+      }}
+    />
   </div>
 );
 
@@ -98,6 +139,7 @@ const mapStateToProps = state => {
     mainAttribute: state.malcolm.mainAttribute,
     open: state.viewState.openParentPanel,
     openSecondary: state.malcolm.childBlock !== undefined,
+    transitionParent: state.viewState.transitionParent,
     urlPath: state.router.location.pathname,
     footerHeight: state.viewState.footerHeight,
   };
@@ -127,6 +169,14 @@ DrawerContainer.propTypes = {
   childIsInfo: PropTypes.bool.isRequired,
   mainAttribute: PropTypes.string.isRequired,
   footerHeight: PropTypes.number.isRequired,
+  transitionParent: PropTypes.bool.isRequired,
+  theme: PropTypes.shape({
+    palette: PropTypes.shape({
+      background: PropTypes.shape({
+        default: PropTypes.string,
+      }),
+    }),
+  }).isRequired,
 };
 
 DrawerContainer.defaultProps = {

--- a/src/drawerContainer/drawerContainer.test.js
+++ b/src/drawerContainer/drawerContainer.test.js
@@ -24,6 +24,7 @@ describe('DrawerContainer', () => {
         openParentPanel: true,
         openChildPanel: true,
         footerHeight: 10,
+        transitionParent: false,
       },
       malcolm: {
         blocks: {},
@@ -48,6 +49,23 @@ describe('DrawerContainer', () => {
   });
 
   it('renders correctly', () => {
+    const wrapper = shallow(
+      <DrawerContainer
+        store={mockStore(state)}
+        parentTitle="Parent"
+        childTitle="Child"
+        popOutAction={() => {}}
+      >
+        <div>Left</div>
+        <div>Middle</div>
+        <div>Right</div>
+      </DrawerContainer>
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
+  it('renders correctly with panel transition', () => {
+    state.viewState.transitionParent = true;
     const wrapper = shallow(
       <DrawerContainer
         store={mockStore(state)}

--- a/src/infoDetails/infoBuilders.js
+++ b/src/infoDetails/infoBuilders.js
@@ -80,14 +80,28 @@ export const buildAttributeInfo = props => {
         inline: true,
         alarmStatePath: 'calculated.alarms.errorState',
       };
+      if (props.clearError) {
+        info.acknowledgeError = {
+          showLabel: false,
+          label: 'Acknowledge Error',
+          value: 'Acknowledge Error',
+          disabledPath: 'NOT.calculated.errorState',
+          inline: true,
+          tag: 'info:button',
+          functions: {
+            clickHandler: () => props.clearError(attribute.calculated.path),
+          },
+        };
+      }
       if (
         attribute.raw.meta.tags.some(a =>
           ['widget:table', 'widget:textinput'].includes(a)
         )
       ) {
         info.localState = {
-          label: 'Local State',
-          value: 'Discard',
+          label: 'Discard Local State',
+          value: 'Discard Local State',
+          showLabel: false,
           disabledPath: 'NOT.calculated.dirty',
           inline: true,
           tag: 'info:button',
@@ -126,7 +140,8 @@ export const buildAttributeInfo = props => {
           : row >= attribute.raw.value[attribute.localState.labels[0]].length;
         info.localState = {
           label: 'Row local state',
-          value: 'Discard',
+          showLabel: false,
+          value: 'Discard row local state',
           disabled: !(rowFlags._dirty || rowFlags._isChanged) || isNewRow,
           inline: true,
           tag: 'info:button',
@@ -302,6 +317,19 @@ export const buildAttributeInfo = props => {
           ? AlarmStates.MAJOR_ALARM
           : null,
       };
+      if (props.clearError) {
+        info.acknowledgeError = {
+          showLabel: false,
+          label: 'Acknowledge Error',
+          value: 'Acknowledge Error',
+          disabledPath: 'NOT.calculated.errorState',
+          inline: true,
+          tag: 'info:button',
+          functions: {
+            clickHandler: () => props.clearError(attribute.calculated.path),
+          },
+        };
+      }
     } else {
       info.parameterType = {
         label: 'Parameter Type',

--- a/src/infoDetails/infoBuilders.js
+++ b/src/infoDetails/infoBuilders.js
@@ -80,19 +80,17 @@ export const buildAttributeInfo = props => {
         inline: true,
         alarmStatePath: 'calculated.alarms.errorState',
       };
-      info.acknowledgeError = {
-        showLabel: false,
-        label: 'Acknowledge Error',
-        value: 'Acknowledge Error',
-        inline: true,
-        tag: 'info:button',
-        disabledPath: 'NOT.calculated.errorState',
-        functions: {
-          clickHandler: () => {
-            props.clearError(attribute.calculated.path);
-          },
-        },
-      };
+      if (props.clearError) {
+        info.acknowledgeError = {
+          showLabel: false,
+          label: 'Acknowledge Error',
+          value: 'Acknowledge Error',
+          disabledPath: 'NOT.calculated.errorState',
+          inline: true,
+          tag: 'info:button',
+          functions: {},
+        };
+      }
       if (
         attribute.raw.meta.tags.some(a =>
           ['widget:table', 'widget:textinput'].includes(a)
@@ -317,19 +315,17 @@ export const buildAttributeInfo = props => {
           ? AlarmStates.MAJOR_ALARM
           : null,
       };
-      info.acknowledgeError = {
-        showLabel: false,
-        label: 'Acknowledge Error',
-        value: 'Acknowledge Error',
-        disabledPath: 'NOT.calculated.errorState',
-        inline: true,
-        tag: 'info:button',
-        functions: {
-          clickHandler: () => {
-            props.clearError(attribute.calculated.path);
-          },
-        },
-      };
+      if (props.clearError) {
+        info.acknowledgeError = {
+          showLabel: false,
+          label: 'Acknowledge Error',
+          value: 'Acknowledge Error',
+          disabledPath: 'NOT.calculated.errorState',
+          inline: true,
+          tag: 'info:button',
+          functions: {},
+        };
+      }
     } else {
       info.parameterType = {
         label: 'Parameter Type',

--- a/src/infoDetails/infoBuilders.test.js
+++ b/src/infoDetails/infoBuilders.test.js
@@ -134,9 +134,10 @@ describe('info builder', () => {
       alarmStatePath: 'calculated.alarms.dirty',
       disabledPath: 'NOT.calculated.dirty',
       inline: true,
-      label: 'Local State',
+      label: 'Discard Local State',
+      showLabel: false,
       tag: 'info:button',
-      value: 'Discard',
+      value: 'Discard Local State',
     });
   });
 
@@ -152,8 +153,9 @@ describe('info builder', () => {
       disabled: true,
       inline: true,
       label: 'Row local state',
+      showLabel: false,
       tag: 'info:button',
-      value: 'Discard',
+      value: 'Discard row local state',
     });
   });
 

--- a/src/mainMalcolmView/mainMalcolmView.container.js
+++ b/src/mainMalcolmView/mainMalcolmView.container.js
@@ -86,6 +86,7 @@ const mapStateToProps = state => {
     showPalette,
     showInfo,
     footerHeight: state.viewState.footerHeight,
+    openParent: state.viewState.openParentPanel,
   };
 };
 

--- a/src/mainMalcolmView/malcolmPopOut.container.js
+++ b/src/mainMalcolmView/malcolmPopOut.container.js
@@ -9,6 +9,7 @@ import BlockDetails from '../blockDetails/blockDetails.component';
 // eslint-disable-next-line import/no-named-as-default
 import InfoDetails from '../infoDetails/infoDetails.component';
 import NavTypes from '../malcolm/NavTypes';
+import { flagAsPopout } from '../viewState/viewState.actions';
 
 const styles = theme => ({
   container: {
@@ -27,24 +28,30 @@ const styles = theme => ({
   },
 });
 
-const MalcolmPopOut = props => (
-  <div className={props.classes.container}>
-    <AppBar position="static">
-      <Toolbar className={props.classes.toolbar}>
-        <Typography
-          variant="title"
-          color="inherit"
-          className={props.classes.title}
-        >
-          {props.paneTitle}
-        </Typography>
-      </Toolbar>
-    </AppBar>
-    {props.isInfo ? <InfoDetails /> : <BlockDetails parent />}
-  </div>
-);
+const MalcolmPopOut = props => {
+  if (!props.statePopoutFlag) {
+    props.setIsPopout();
+  }
+  return (
+    <div className={props.classes.container}>
+      <AppBar position="static">
+        <Toolbar className={props.classes.toolbar}>
+          <Typography
+            variant="title"
+            color="inherit"
+            className={props.classes.title}
+          >
+            {props.paneTitle}
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      {props.isInfo ? <InfoDetails /> : <BlockDetails parent />}
+    </div>
+  );
+};
 
 const mapStateToProps = state => {
+  const statePopoutFlag = state.viewState.popout;
   const parentBlock = state.malcolm.parentBlock
     ? state.malcolm.blocks[state.malcolm.parentBlock]
     : undefined;
@@ -68,10 +75,15 @@ const mapStateToProps = state => {
     parentBlock,
     isInfo,
     paneTitle,
+    statePopoutFlag,
   };
 };
 
-const mapDispatchToProps = () => ({});
+const mapDispatchToProps = dispatch => ({
+  setIsPopout: () => {
+    dispatch(flagAsPopout());
+  },
+});
 
 MalcolmPopOut.propTypes = {
   paneTitle: PropTypes.string.isRequired,
@@ -81,6 +93,8 @@ MalcolmPopOut.propTypes = {
     title: PropTypes.string,
   }).isRequired,
   isInfo: PropTypes.bool.isRequired,
+  setIsPopout: PropTypes.func.isRequired,
+  statePopoutFlag: PropTypes.bool.isRequired,
 };
 
 export default withStyles(styles, { withTheme: true })(

--- a/src/mainMalcolmView/malcolmPopOut.test.js
+++ b/src/mainMalcolmView/malcolmPopOut.test.js
@@ -24,6 +24,9 @@ describe('MalcolmPopOut', () => {
           navigationLists: [{ path: 'test1', navType: NavTypes.Block }],
         },
       },
+      viewState: {
+        popout: true,
+      },
     };
 
     const mockStore = configureStore();
@@ -50,6 +53,9 @@ describe('MalcolmPopOut', () => {
             { path: '.info', navType: NavTypes.Info },
           ],
         },
+      },
+      viewState: {
+        popout: true,
       },
     };
 

--- a/src/malcolm/actions/navigation.actions.js
+++ b/src/malcolm/actions/navigation.actions.js
@@ -1,3 +1,4 @@
+/* eslint no-unused-expressions: ["error", { "allowTernary": true }] */
 import { replace, push } from 'react-router-redux';
 import NavTypes from '../NavTypes';
 import {
@@ -89,7 +90,12 @@ const navigateToAttribute = (blockMri, attributeName) => (
       .filter((nav, i) => i <= matchingBlockNav)
       .map(nav => nav.path)
       .join('/')}/${attributeName}`;
-    dispatch(push(newPath));
+    getState().viewState.popout
+      ? window.open(
+          `${window.location.protocol}//${window.location.host}${newPath}`,
+          `${blockMri}.${attributeName}`
+        )
+      : dispatch(push(newPath));
   }
 };
 
@@ -99,21 +105,29 @@ const navigateToInfo = (blockMri, attributeName, subElement) => (
 ) => {
   const state = getState().malcolm;
   const { navigationLists } = state.navigation;
-
   const matchingBlockNav = findBlockIndex(navigationLists, blockMri);
+
+  const goTo = path =>
+    getState().viewState.popout
+      ? window.open(
+          `${window.location.protocol}//${window.location.host}${path}`,
+          `${blockMri}.${attributeName}`
+        )
+      : dispatch(push(path));
+
   if (matchingBlockNav > -1) {
     if (subElement !== undefined) {
       const newPath = `/gui/${navigationLists
         .filter((nav, i) => i <= matchingBlockNav)
         .map(nav => nav.path)
         .join('/')}/${attributeName}.${subElement}/.info`;
-      dispatch(push(newPath));
+      goTo(newPath);
     } else {
       const newPath = `/gui/${navigationLists
         .filter((nav, i) => i <= matchingBlockNav)
         .map(nav => nav.path)
         .join('/')}/${attributeName}/.info`;
-      dispatch(push(newPath));
+      goTo(newPath);
     }
   }
 };

--- a/src/malcolm/actions/navigation.actions.test.js
+++ b/src/malcolm/actions/navigation.actions.test.js
@@ -31,6 +31,9 @@ const buildNavState = () => ({
       ],
     },
   },
+  viewState: {
+    popout: false,
+  },
 });
 
 describe('subscribeToNewBlocksInRoute', () => {

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -13,6 +13,7 @@ import AttributeAlarm, {
 import AttributeSelector from './attributeSelector/attributeSelector.component';
 import blockUtils from '../../malcolm/blockUtils';
 import navigationActions from '../../malcolm/actions/navigation.actions';
+import { parentPanelTransition } from '../../viewState/viewState.actions';
 
 const styles = theme => ({
   div: {
@@ -183,7 +184,11 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = dispatch => ({
   buttonClickHandler: (blockName, attributeName) => {
-    dispatch(navigationActions.navigateToInfo(blockName, attributeName));
+    dispatch(parentPanelTransition(true));
+    setTimeout(() => {
+      dispatch(navigationActions.navigateToInfo(blockName, attributeName));
+      dispatch(parentPanelTransition(false));
+    }, 550);
   },
 });
 

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -72,8 +72,18 @@ const AttributeDetails = props => {
             tabIndex="-1"
             className={props.classes.button}
             disableRipple
-            onClick={() =>
-              props.buttonClickHandler(props.blockName, props.attributeName)
+            onClick={
+              props.isGrandchild
+                ? () =>
+                    props.buttonClickHandlerWithTransition(
+                      props.blockName,
+                      props.attributeName
+                    )
+                : () =>
+                    props.buttonClickHandler(
+                      props.blockName,
+                      props.attributeName
+                    )
             }
           >
             <AttributeAlarm alarmSeverity={props.alarm} />
@@ -113,7 +123,9 @@ AttributeDetails.propTypes = {
     button: PropTypes.string,
   }).isRequired,
   buttonClickHandler: PropTypes.func.isRequired,
+  buttonClickHandlerWithTransition: PropTypes.func.isRequired,
   isMainAttribute: PropTypes.bool.isRequired,
+  isGrandchild: PropTypes.bool.isRequired,
   theme: PropTypes.shape({
     palette: PropTypes.shape({
       secondary: PropTypes.shape({
@@ -179,16 +191,20 @@ const mapStateToProps = (state, ownProps) => {
       attribute.calculated &&
       ownProps.blockName === state.malcolm.parentBlock &&
       state.malcolm.mainAttribute === attribute.calculated.name,
+    isGrandchild: ownProps.blockName === state.malcolm.childBlock,
   };
 };
 
 const mapDispatchToProps = dispatch => ({
-  buttonClickHandler: (blockName, attributeName) => {
+  buttonClickHandlerWithTransition: (blockName, attributeName) => {
     dispatch(parentPanelTransition(true));
     setTimeout(() => {
       dispatch(navigationActions.navigateToInfo(blockName, attributeName));
       dispatch(parentPanelTransition(false));
     }, 550);
+  },
+  buttonClickHandler: (blockName, attributeName) => {
+    dispatch(navigationActions.navigateToInfo(blockName, attributeName));
   },
 });
 

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.test.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.test.js
@@ -3,8 +3,12 @@ import { createShallow, createMount } from '@material-ui/core/test-utils';
 import { Provider } from 'react-redux';
 import AttributeDetails from './attributeDetails.component';
 import navigationActions from '../../malcolm/actions/navigation.actions';
+import { parentPanelTransition } from '../../viewState/viewState.actions';
 
+jest.mock('../../viewState/viewState.actions');
 jest.mock('../../malcolm/actions/navigation.actions');
+
+jest.useFakeTimers();
 
 describe('AttributeDetails', () => {
   let shallow;
@@ -14,6 +18,8 @@ describe('AttributeDetails', () => {
   const actions = [];
 
   beforeEach(() => {
+    navigationActions.navigateToInfo.mockClear();
+    parentPanelTransition.mockClear();
     mockStore = {
       getState: () => state,
       dispatch: action => actions.push(action),
@@ -81,6 +87,31 @@ describe('AttributeDetails', () => {
       'block1',
       'Attribute1'
     );
+  });
+  it('info button hooks up correctly if grandchild', () => {
+    const attribute = buildAttribute();
+    state.malcolm.blocks.block1.attributes.push(attribute);
+    state.malcolm.childBlock = 'block1';
+
+    const wrapper = mount(
+      <Provider store={mockStore}>
+        <AttributeDetails blockName="block1" attributeName="Attribute1" />
+      </Provider>
+    );
+    wrapper
+      .find('button')
+      .first()
+      .simulate('click');
+    expect(parentPanelTransition).toHaveBeenCalledTimes(1);
+    expect(parentPanelTransition).toHaveBeenCalledWith(true);
+    jest.runAllTimers();
+    expect(navigationActions.navigateToInfo).toHaveBeenCalledTimes(1);
+    expect(navigationActions.navigateToInfo).toHaveBeenCalledWith(
+      'block1',
+      'Attribute1'
+    );
+    expect(parentPanelTransition).toHaveBeenCalledTimes(2);
+    expect(parentPanelTransition).toHaveBeenCalledWith(false);
   });
 
   it('middle click hooks up correctly', () => {

--- a/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
@@ -19,6 +19,7 @@ import {
 import ButtonAction from '../../buttonAction/buttonAction.component';
 import navigationActions from '../../../malcolm/actions/navigation.actions';
 import blockUtils from '../../../malcolm/blockUtils';
+import { parentPanelTransition } from '../../../viewState/viewState.actions';
 
 export const malcolmTypes = {
   bool: 'malcolm:core/BooleanMeta:1.0',
@@ -157,6 +158,17 @@ export const selectorFunction = (
           disabled={flags.isDisabled}
         />
       );
+    case 'widget:help':
+      return (
+        <ButtonAction
+          method
+          text={value}
+          clickAction={() =>
+            window.open('http://github.com/dls-controls/pymalcolm')
+          }
+          disabled={flags.isDisabled}
+        />
+      );
     case 'info:alarm':
       return <AttributeAlarm alarmSeverity={value} />;
     default:
@@ -201,7 +213,9 @@ const AttributeSelector = props => {
         props.attribute.raw.meta,
         props.attribute.calculated.forceUpdate,
         continuousSend,
-        props.buttonClickHandler,
+        props.isGrandchild
+          ? props.buttonClickHandlerWithTransition
+          : props.buttonClickHandler,
         {
           value: props.attribute.localState,
           set: event =>
@@ -225,6 +239,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     attribute,
+    isGrandchild: ownProps.blockName === state.malcolm.childBlock,
   };
 };
 
@@ -238,7 +253,14 @@ const mapDispatchToProps = dispatch => ({
   },
   buttonClickHandler: path => {
     dispatch(navigationActions.navigateToAttribute(path[0], path[1]));
-    // dispatch(push(`/gui/${path[0]}/${path[1]}`));
+  },
+
+  buttonClickHandlerWithTransition: path => {
+    dispatch(parentPanelTransition(true));
+    setTimeout(() => {
+      dispatch(navigationActions.navigateToAttribute(path[0], path[1]));
+      dispatch(parentPanelTransition(false));
+    }, 550);
   },
   setLocalState: (path, value) => {
     dispatch(writeLocalState(path, value));
@@ -278,6 +300,7 @@ AttributeSelector.propTypes = {
   }).isRequired,
   eventHandler: PropTypes.func.isRequired,
   buttonClickHandler: PropTypes.func.isRequired,
+  buttonClickHandlerWithTransition: PropTypes.func.isRequired,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/src/malcolmWidgets/comboBox/__snapshots__/comboBox.test.js.snap
+++ b/src/malcolmWidgets/comboBox/__snapshots__/comboBox.test.js.snap
@@ -26,11 +26,105 @@ exports[`WidgetComboBox renders correctly 1`] = `
     value="2"
   >
     <option
-      disabled={true}
-      value={null}
+      key="0"
+      value="1"
     >
-       
+      1
     </option>
+    <option
+      key="1"
+      value="2"
+    >
+      2
+    </option>
+    <option
+      key="2"
+      value="3"
+    >
+      3
+    </option>
+  </WithStyles(Select)>
+</FormControl>
+`;
+
+exports[`WidgetComboBox renders correctly with invalid value 1`] = `
+<FormControl
+  className="WidgetComboBox-formControl-2"
+  classes={
+    Object {
+      "fullWidth": "MuiFormControl-fullWidth-7",
+      "marginDense": "MuiFormControl-marginDense-6",
+      "marginNormal": "MuiFormControl-marginNormal-5",
+      "root": "MuiFormControl-root-4",
+    }
+  }
+  component="div"
+  disabled={false}
+  error={false}
+  fullWidth={true}
+  margin="none"
+  required={false}
+  variant="standard"
+>
+  <WithStyles(Select)
+    className="WidgetComboBox-select-3"
+    native={true}
+    onChange={[Function]}
+    value="4"
+  >
+    <option
+      key="0"
+      value="1"
+    >
+      1
+    </option>
+    <option
+      key="1"
+      value="2"
+    >
+      2
+    </option>
+    <option
+      key="2"
+      value="3"
+    >
+      3
+    </option>
+    <option
+      disabled={true}
+      value="4"
+    >
+      4
+    </option>
+  </WithStyles(Select)>
+</FormControl>
+`;
+
+exports[`WidgetComboBox renders correctly with null initial value 1`] = `
+<FormControl
+  className="WidgetComboBox-formControl-2"
+  classes={
+    Object {
+      "fullWidth": "MuiFormControl-fullWidth-7",
+      "marginDense": "MuiFormControl-marginDense-6",
+      "marginNormal": "MuiFormControl-marginNormal-5",
+      "root": "MuiFormControl-root-4",
+    }
+  }
+  component="div"
+  disabled={false}
+  error={false}
+  fullWidth={true}
+  margin="none"
+  required={false}
+  variant="standard"
+>
+  <WithStyles(Select)
+    className="WidgetComboBox-select-3"
+    native={true}
+    onChange={[Function]}
+    value="1"
+  >
     <option
       key="0"
       value="1"

--- a/src/malcolmWidgets/comboBox/comboBox.component.js
+++ b/src/malcolmWidgets/comboBox/comboBox.component.js
@@ -20,6 +20,7 @@ const styles = theme => ({
 });
 
 const WidgetComboBox = props => {
+  const value = props.Value !== null ? props.Value : props.Choices[0];
   const options = props.Choices.map((choice, index) => (
     // Rule prevents behaviour we want in this case
     // eslint-disable-next-line react/no-array-index-key
@@ -27,6 +28,13 @@ const WidgetComboBox = props => {
       {choice}
     </option>
   ));
+  if (!props.Choices.includes(value)) {
+    options.push(
+      <option value={value} disabled>
+        {value}
+      </option>
+    );
+  }
   return (
     <FormControl
       disabled={props.Pending}
@@ -35,13 +43,10 @@ const WidgetComboBox = props => {
     >
       <Select
         native
-        value={props.Value}
+        value={value}
         onChange={props.selectEventHandler}
         className={props.classes.select}
       >
-        <option value={null} disabled={props.Value !== null}>
-          {' '}
-        </option>
         {options}
       </Select>
     </FormControl>

--- a/src/malcolmWidgets/comboBox/comboBox.test.js
+++ b/src/malcolmWidgets/comboBox/comboBox.test.js
@@ -27,6 +27,30 @@ describe('WidgetComboBox', () => {
     expect(wrapper.dive()).toMatchSnapshot();
   });
 
+  it('renders correctly with invalid value', () => {
+    const wrapper = shallow(
+      <WidgetComboBox
+        Value="4"
+        Pending={false}
+        Choices={['1', '2', '3']}
+        selectEventHandler={() => {}}
+      />
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
+  it('renders correctly with null initial value', () => {
+    const wrapper = shallow(
+      <WidgetComboBox
+        Value={null}
+        Pending={false}
+        Choices={['1', '2', '3']}
+        selectEventHandler={() => {}}
+      />
+    );
+    expect(wrapper.dive()).toMatchSnapshot();
+  });
+
   it('calls change', () => {
     const eventAction = jest.fn();
     const wrapper = mount(

--- a/src/middlePanelViews/__snapshots__/plotter.component.test.js.snap
+++ b/src/middlePanelViews/__snapshots__/plotter.component.test.js.snap
@@ -98,6 +98,7 @@ exports[`MethodPlot renders correctly for returns 1`] = `
       },
     ]
   }
+  data-cy="plotter"
   debug={false}
   divId="plotComponent"
   layout={
@@ -234,6 +235,7 @@ exports[`MethodPlot renders correctly for takes 1`] = `
       },
     ]
   }
+  data-cy="plotter"
   debug={false}
   divId="plotComponent"
   layout={
@@ -370,6 +372,7 @@ exports[`attributePlot renders correctly for bool 1`] = `
       },
     ]
   }
+  data-cy="plotter"
   debug={false}
   divId="plotComponent"
   layout={
@@ -506,6 +509,7 @@ exports[`attributePlot renders correctly for changing alarm state 1`] = `
       },
     ]
   }
+  data-cy="plotter"
   debug={false}
   divId="plotComponent"
   layout={
@@ -642,6 +646,7 @@ exports[`attributePlot renders correctly for number 1`] = `
       },
     ]
   }
+  data-cy="plotter"
   debug={false}
   divId="plotComponent"
   layout={

--- a/src/middlePanelViews/plotter.component.js
+++ b/src/middlePanelViews/plotter.component.js
@@ -192,6 +192,7 @@ class Plotter extends React.Component {
         useResizeHandler
         onRelayout={this.finishChangingViewState}
         divId="plotComponent"
+        data-cy="plotter"
       />
     );
   }

--- a/src/middlePanelViews/tabbedMiddlePanel.component.js
+++ b/src/middlePanelViews/tabbedMiddlePanel.component.js
@@ -88,7 +88,11 @@ class TabbedPanel extends React.Component {
           fullWidth
         >
           <Tab label={this.props.tabLabels[0]} />
-          <Tab label={this.props.tabLabels[1]} disabled={disablePlotView} />
+          <Tab
+            label={this.props.tabLabels[1]}
+            disabled={disablePlotView}
+            data-cy="plotTab"
+          />
         </Tabs>
       </div>
     );

--- a/src/viewState/viewState.actions.js
+++ b/src/viewState/viewState.actions.js
@@ -2,6 +2,7 @@ export const openParentPanelType = 'OPEN_PARENT_PANEL';
 export const updateVersionNumerType = 'UPDATE_VERSION';
 export const showFooterType = 'SHOW_FOOTER_TYPE';
 export const snackbar = 'PUSH_SNACKBAR';
+export const popout = 'WINDOW_IS_POPOUT';
 
 export const openParentPanel = open => ({
   type: openParentPanelType,
@@ -29,6 +30,10 @@ export const showFooterAction = footerHeight => ({
   payload: {
     footerHeight,
   },
+});
+
+export const flagAsPopout = () => ({
+  type: popout,
 });
 
 export default {

--- a/src/viewState/viewState.actions.js
+++ b/src/viewState/viewState.actions.js
@@ -3,6 +3,7 @@ export const updateVersionNumerType = 'UPDATE_VERSION';
 export const showFooterType = 'SHOW_FOOTER_TYPE';
 export const snackbar = 'PUSH_SNACKBAR';
 export const popout = 'WINDOW_IS_POPOUT';
+export const panelDirection = 'PANEL_TRANSITION_DIRECTION';
 
 export const openParentPanel = open => ({
   type: openParentPanelType,
@@ -34,6 +35,13 @@ export const showFooterAction = footerHeight => ({
 
 export const flagAsPopout = () => ({
   type: popout,
+});
+
+export const parentPanelTransition = transition => ({
+  type: panelDirection,
+  payload: {
+    transition,
+  },
 });
 
 export default {

--- a/src/viewState/viewState.reducer.js
+++ b/src/viewState/viewState.reducer.js
@@ -4,6 +4,7 @@ import {
   snackbar,
   showFooterType,
   popout,
+  panelDirection,
 } from './viewState.actions';
 
 const initialViewState = {
@@ -14,6 +15,7 @@ const initialViewState = {
     open: false,
   },
   footerHeight: 0,
+  transitionParent: false,
 };
 
 const viewStateReducer = (state = initialViewState, action = {}) => {
@@ -43,6 +45,11 @@ const viewStateReducer = (state = initialViewState, action = {}) => {
       return {
         ...state,
         popout: true,
+      };
+    case panelDirection:
+      return {
+        ...state,
+        transitionParent: action.payload.transition,
       };
     default:
       return state;

--- a/src/viewState/viewState.reducer.js
+++ b/src/viewState/viewState.reducer.js
@@ -3,6 +3,7 @@ import {
   updateVersionNumerType,
   snackbar,
   showFooterType,
+  popout,
 } from './viewState.actions';
 
 const initialViewState = {
@@ -38,6 +39,11 @@ const viewStateReducer = (state = initialViewState, action = {}) => {
         footerHeight: action.payload.footerHeight || 0,
       };
 
+    case popout:
+      return {
+        ...state,
+        popout: true,
+      };
     default:
       return state;
   }


### PR DESCRIPTION
## Description

- Changed combobox behaviour so it defaults to first element and displays the given value even if it is not in its choices (in which case the value is not selectable).
- Added transition effect for when child panel becomes parent
- Changed buttons in info panes which launch new views to all launch a new full size window

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/PANDA/layout/SEQ1
- click on the edit button on the table attribute in the child pane and see the transition
- click the popout button on the parent pane and check that clicking the edit button in the new window launches another new, full size window

## Agile board tracking

connect to #312 
closes #312 
connect to #422 
closes #422