### PR TITLE
Feature/widget help

### DIFF
--- a/server/canned_data/Sub/PANDA/request_help.json
+++ b/server/canned_data/Sub/PANDA/request_help.json
@@ -1,0 +1,9 @@
+{
+  "typeid": "malcolm:core/Subscribe:1.0", 
+  "id": "CANNED", 
+  "path": [
+    "PANDA", 
+    "help"
+  ], 
+  "delta": true
+}

--- a/server/canned_data/Sub/PANDA/response_help.json
+++ b/server/canned_data/Sub/PANDA/response_help.json
@@ -1,0 +1,34 @@
+{
+  "typeid": "malcolm:core/Delta:1.0", 
+  "id": "CANNED", 
+  "changes": [
+    [
+      [], 
+      {
+        "typeid": "epics:nt/NTScalar:1.0", 
+        "value": "https://github.com/dls-controls/pymalcolm", 
+        "alarm": {
+          "typeid": "alarm_t", 
+          "severity": 0, 
+          "status": 0, 
+          "message": ""
+        }, 
+        "timeStamp": {
+          "typeid": "time_t", 
+          "secondsPastEpoch": 0, 
+          "nanoseconds": 0, 
+          "userTag": 0
+        }, 
+        "meta": {
+          "typeid": "malcolm:core/StringMeta:1.0", 
+          "description": "Link to help page", 
+          "tags": [
+            "widget:help"
+          ], 
+          "writeable": false, 
+          "label": "Help"
+        }
+      }
+    ]
+  ]
+}

--- a/server/canned_data/Sub/PANDA/response_meta.json
+++ b/server/canned_data/Sub/PANDA/response_meta.json
@@ -19,7 +19,8 @@
           "design", 
           "exports", 
           "modified", 
-          "save"
+          "save",
+	  "help"
         ]
       }
     ]

--- a/server/canned_data/Sub/blocks/request_info.json
+++ b/server/canned_data/Sub/blocks/request_info.json
@@ -3,7 +3,8 @@
   "id": "CANNED", 
   "path": [
     ".", 
-    "blocks"
+    "blocks",
+    "value"
   ], 
   "delta": false
 }

--- a/src/blockDetails/blockDetails.component.js
+++ b/src/blockDetails/blockDetails.component.js
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import GroupExpander from '../malcolmWidgets/groupExpander/groupExpander.component';
 import AttributeDetails from '../malcolmWidgets/attributeDetails/attributeDetails.component';
 import MethodDetails from '../malcolmWidgets/method/method.component';
+import blockUtils from '../malcolm/blockUtils';
 
 const ascii404 =
   '                __     __      _____      __     __ \n' +
@@ -228,14 +229,20 @@ const mapStateToProps = (state, ownProps, memory) => {
     (!areAttributesTheSame(stateMemory.oldAttributes, block.attributes) ||
       block.orphans.some(a => !stateMemory.orphans.includes(a)))
   ) {
-    stateMemory.rootAttributes = block.attributes.filter(
-      a =>
-        isRootLevelAttribute(a) &&
-        !(
-          block.orphans &&
-          block.orphans.some(orphan => orphan === a.calculated.name)
-        )
-    );
+    stateMemory.rootAttributes = [
+      ...block.attributes.filter(a =>
+        blockUtils.attributeHasTag(a, 'widget:help')
+      ),
+      ...block.attributes.filter(
+        a =>
+          isRootLevelAttribute(a) &&
+          !(
+            block.orphans &&
+            block.orphans.some(orphan => orphan === a.calculated.name)
+          ) &&
+          !blockUtils.attributeHasTag(a, 'widget:help')
+      ),
+    ];
     stateMemory.orphans = block.orphans;
     stateMemory.groups = block.attributes
       .filter(a => a.calculated.isGroup)

--- a/src/layout/block/BlockNodeModel.js
+++ b/src/layout/block/BlockNodeModel.js
@@ -10,6 +10,7 @@ class BlockNodeModel extends NodeModel {
     this.label = block.name;
     this.description = block.description;
     this.loading = block.loading;
+    this.locked = block.locked;
     this.isHiddenLink = block.isHiddenLink;
     this.hasHiddenLink = block.hasHiddenLink;
     this.addBlockPort = this.addBlockPort.bind(this);

--- a/src/malcolm/malcolmActionCreators.js
+++ b/src/malcolm/malcolmActionCreators.js
@@ -141,7 +141,7 @@ export const malcolmResetBlocks = () => (dispatch, getState) => {
 
   const state = getState();
   state.malcolm.messagesInFlight = {};
-  dispatch(malcolmSubscribeAction(['.', 'blocks'], false));
+  dispatch(malcolmSubscribeAction(['.', 'blocks', 'value'], false));
   Object.values(state.malcolm.blocks)
     .filter(block => block.name !== '.blocks')
     .forEach(block => {

--- a/src/malcolm/malcolmSocketHandler.js
+++ b/src/malcolm/malcolmSocketHandler.js
@@ -25,7 +25,10 @@ const handleMessages = (messages, dispatch, getState) => {
     const { data, originalRequest } = message;
     switch (data.typeid) {
       case 'malcolm:core/Update:1.0': {
-        if (originalRequest.path.join('') === '.blocks') {
+        if (
+          JSON.stringify(originalRequest.path) ===
+          JSON.stringify(['.', 'blocks', 'value'])
+        ) {
           RootBlockHandler(originalRequest, data.value, dispatch, getState());
         }
 

--- a/src/malcolm/malcolmSocketHandler.test.js
+++ b/src/malcolm/malcolmSocketHandler.test.js
@@ -121,7 +121,7 @@ describe('malcolm socket handler', () => {
           },
           4: {
             id: 4,
-            path: ['.', 'blocks'],
+            path: ['.', 'blocks', 'value'],
           },
         },
         blocks: {
@@ -196,7 +196,7 @@ describe('malcolm socket handler', () => {
     expect(dispatches[2].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
     expect(dispatches[2].payload.path).toEqual(['Test:TestBlock', 'meta']);
     expect(dispatches[1].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
-    expect(dispatches[1].payload.path).toEqual(['.', 'blocks']);
+    expect(dispatches[1].payload.path).toEqual(['.', 'blocks', 'value']);
   });
 
   it('does nothing on receiving a non-malcolm message', () => {

--- a/src/malcolm/middleware/malcolmReduxMiddleware.test.js
+++ b/src/malcolm/middleware/malcolmReduxMiddleware.test.js
@@ -155,6 +155,6 @@ describe('malcolm redux middleware', () => {
 
     expect(dispatches[2].type).toEqual(MalcolmSend);
     expect(dispatches[2].payload.typeid).toEqual('malcolm:core/Subscribe:1.0');
-    expect(dispatches[2].payload.path).toEqual(['.', 'blocks']);
+    expect(dispatches[2].payload.path).toEqual(['.', 'blocks', 'value']);
   });
 });

--- a/src/malcolm/middleware/malcolmRouting.js
+++ b/src/malcolm/middleware/malcolmRouting.js
@@ -16,7 +16,7 @@ const handleLocationChange = (path, blocks, dispatch, getState) => {
   // Get the root list of blocks
   if (!blocks['.blocks']) {
     dispatch(malcolmNewBlockAction('.blocks', false, false));
-    dispatch(malcolmSubscribeAction(['.', 'blocks'], false));
+    dispatch(malcolmSubscribeAction(['.', 'blocks', 'value'], false));
   } else {
     const { navigationLists } = getState().malcolm.navigation;
     const newBlocks = navigationLists.filter(

--- a/src/malcolm/reducer/layout/layout.reducer.js
+++ b/src/malcolm/reducer/layout/layout.reducer.js
@@ -129,6 +129,7 @@ const findHiddenLinks = (layoutBlocks, layoutEngine) => {
             },
           ],
           visible: true,
+          locked: true,
         };
         updatedPort.value = newValue;
         hiddenLinkEnd.position.x -= 50;

--- a/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component.js
@@ -6,8 +6,10 @@ import InfoOutline from '@material-ui/icons/InfoOutlined';
 import HighlightOff from '@material-ui/icons/HighlightOff';
 import Edit from '@material-ui/icons/Edit';
 import PowerOff from '@material-ui/icons/PowerOff';
+import Help from '@material-ui/icons/HelpOutline';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { withTheme } from '@material-ui/core/styles/index';
+import blockUtils from '../../../malcolm/blockUtils';
 import EditError from './EditError.component';
 
 const AlarmStateNumbers = {
@@ -19,6 +21,7 @@ const AlarmStateNumbers = {
   PENDING: -1,
   DIRTY: -2,
   DIRTYANDERROR: -3,
+  HELP: -4,
 };
 
 Object.entries(AlarmStateNumbers).forEach(entry => {
@@ -35,6 +38,10 @@ export const AlarmStatesByIndex = [
 ];
 
 export const getAlarmState = attribute => {
+  if (blockUtils.attributeHasTag(attribute, 'widget:help')) {
+    return AlarmStates.HELP;
+  }
+
   let alarm = AlarmStates.NO_ALARM;
   if (attribute && attribute.raw && attribute.raw.alarm) {
     alarm = attribute.raw.alarm.severity;
@@ -82,6 +89,9 @@ const AttributeAlarm = props => {
 
     case AlarmStates.DIRTYANDERROR:
       return <EditError nativeColor={props.theme.palette.error.main} />;
+
+    case AlarmStates.HELP:
+      return <Help nativeColor={props.theme.palette.secondary.dark} />;
 
     default:
       return <div style={{ width: 24 }} />;

--- a/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
@@ -161,12 +161,10 @@ export const selectorFunction = (
     case 'widget:help':
       return (
         <ButtonAction
-          method
-          text={value}
+          text="View"
           clickAction={() =>
             window.open('http://github.com/dls-controls/pymalcolm')
           }
-          disabled={flags.isDisabled}
         />
       );
     case 'info:alarm':

--- a/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component.js
@@ -160,12 +160,7 @@ export const selectorFunction = (
       );
     case 'widget:help':
       return (
-        <ButtonAction
-          text="View"
-          clickAction={() =>
-            window.open('http://github.com/dls-controls/pymalcolm')
-          }
-        />
+        <ButtonAction text="View" clickAction={() => window.open(value)} />
       );
     case 'info:alarm':
       return <AttributeAlarm alarmSeverity={value} />;


### PR DESCRIPTION
## Description

- added new help widget which links to a specified url (opened in a new window)
- changed block list subscription to subscribe to ['.', 'blocks', 'value'] instead of ['.', 'blocks'] (for use with newest version of pymalcolm)

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/gui/PANDA
- see the new help attribute at the top of the parent pane
- click the view button on the help attribute and check a new page is launched (should navigate to github page for pymalcolm)
