### PR TITLE
Feature/table scrollbars #398

### DIFF
--- a/src/infoDetails/infoBuilders.js
+++ b/src/infoDetails/infoBuilders.js
@@ -162,30 +162,49 @@ export const buildAttributeInfo = props => {
               ? attribute.raw.value[row]
               : 'undefined';
         }
+        info.rowOperations = {
+          label: 'Row Operations',
+          moveRowUp: {
+            label: 'Shift row up',
+            value: 'Shift row up',
+            showLabel: false,
+            disabled: row === 0,
+            tag: 'info:button',
+          },
+          moveRowDown: {
+            label: 'Shift row down',
+            value: 'Shift row down',
+            showLabel: false,
+            disabled: row === attribute.localState.value.length - 1,
+            tag: 'info:button',
+          },
+          addRowAbove: {
+            label: 'Insert row above',
+            value: 'Insert row above',
+            showLabel: false,
+            tag: 'info:button',
+          },
+          addRowBelow: {
+            label: 'Insert row below',
+            value: 'Insert row below',
+            showLabel: false,
+            tag: 'info:button',
+          },
+          deleteRow: {
+            label: 'Delete row',
+            value: 'Delete',
+            inline: true,
+            showLabel: false,
+            tag: 'info:button',
+          },
+        };
         info.rowValue = {
           label: 'Row remote state',
           ...dataRow,
         };
-        info.addRowAbove = {
-          label: 'Insert row above',
-          value: 'Add',
-          inline: true,
-          tag: 'info:button',
-        };
-        info.addRowBelow = {
-          label: 'Insert row below',
-          value: 'Add',
-          inline: true,
-          tag: 'info:button',
-        };
-        info.deleteRow = {
-          label: 'Delete row',
-          value: 'Delete',
-          inline: true,
-          tag: 'info:button',
-        };
+
         if (props.addRow) {
-          info.addRowAbove.functions = {
+          info.rowOperations.addRowAbove.functions = {
             clickHandler: () => {
               props.addRow(props.attribute.calculated.path, row);
               props.changeInfoHandler(
@@ -194,12 +213,12 @@ export const buildAttributeInfo = props => {
               );
             },
           };
-          info.addRowBelow.functions = {
+          info.rowOperations.addRowBelow.functions = {
             clickHandler: () => {
               props.addRow(props.attribute.calculated.path, row, 'below');
             },
           };
-          info.deleteRow.functions = {
+          info.rowOperations.deleteRow.functions = {
             clickHandler: () => {
               if (row >= props.attribute.localState.value.length - 1) {
                 if (row !== 0) {
@@ -212,6 +231,26 @@ export const buildAttributeInfo = props => {
                 }
               }
               props.addRow(props.attribute.calculated.path, row, 'delete');
+            },
+          };
+        }
+        if (props.moveRow) {
+          info.rowOperations.moveRowUp.functions = {
+            clickHandler: () => {
+              props.moveRow(props.attribute.calculated.path, row);
+              props.changeInfoHandler(
+                props.attribute.calculated.path,
+                `row.${row - 1}`
+              );
+            },
+          };
+          info.rowOperations.moveRowDown.functions = {
+            clickHandler: () => {
+              props.moveRow(props.attribute.calculated.path, row, 'below');
+              props.changeInfoHandler(
+                props.attribute.calculated.path,
+                `row.${row + 1}`
+              );
             },
           };
         }

--- a/src/infoDetails/infoBuilders.js
+++ b/src/infoDetails/infoBuilders.js
@@ -127,6 +127,13 @@ export const buildAttributeInfo = props => {
         }
       }
       ({ value } = attribute.raw);
+      if (attribute.raw.meta.typeid === malcolmTypes.table) {
+        info.columnHeadings = {
+          label: 'Columns',
+          value: JSON.stringify(Object.keys(attribute.raw.meta.elements)),
+          inline: true,
+        };
+      }
     } else if (
       (attribute.raw.meta.typeid === malcolmTypes.table ||
         isArrayType(attribute.raw.meta)) &&
@@ -271,6 +278,21 @@ export const buildAttributeInfo = props => {
         info.columnHeading = {
           label: 'Column',
           value: props.subElement[1],
+          inline: true,
+        };
+        info.columnDescription = {
+          label: 'Description',
+          value: attribute.raw.meta.elements[props.subElement[1]].description,
+          inline: true,
+        };
+        info.columnType = {
+          label: 'Type',
+          value: attribute.raw.meta.elements[props.subElement[1]].typeid,
+          inline: true,
+        };
+        info.columnWriteable = {
+          label: 'Writeable',
+          value: attribute.raw.meta.elements[props.subElement[1]].writeable,
           inline: true,
         };
       }

--- a/src/infoDetails/infoBuilders.test.js
+++ b/src/infoDetails/infoBuilders.test.js
@@ -1,5 +1,8 @@
-import { harderAttribute } from '../malcolmWidgets/table/table.stories';
-
+import {
+  harderAttribute,
+  expectedCopy,
+} from '../malcolmWidgets/table/table.stories';
+import { malcolmTypes } from '../malcolmWidgets/attributeDetails/attributeSelector/attributeSelector.component';
 import { buildAttributeInfo } from './infoBuilders';
 
 describe('info builder', () => {
@@ -42,6 +45,7 @@ describe('info builder', () => {
 
   it('attribute info builder generates correct structure for basic attribute', () => {
     props.attribute.raw.meta.tags = ['widget:test'];
+    props.attribute.raw.meta.typeid = malcolmTypes.string;
     const infoObject = buildAttributeInfo(props);
     expect(infoObject.info).toEqual({
       errorState: {
@@ -122,6 +126,15 @@ describe('info builder', () => {
           valuePath: 'raw.timeStamp.userTag',
         },
       },
+    });
+  });
+
+  it('attribute info builder adds column list for table attribute', () => {
+    const infoObject = buildAttributeInfo(props);
+    expect(infoObject.info.columnHeadings).toEqual({
+      inline: true,
+      label: 'Columns',
+      value: JSON.stringify(expectedCopy.labels),
     });
   });
 

--- a/src/infoDetails/infoBuilders.test.js
+++ b/src/infoDetails/infoBuilders.test.js
@@ -188,6 +188,7 @@ describe('info builder', () => {
 
   it('table add and delete row methods get hooked up', () => {
     props.addRow = jest.fn();
+    props.moveRow = jest.fn();
     props.changeInfoHandler = jest.fn();
     props.attribute.raw.meta.tags = ['widget:table'];
     props.attribute.calculated.dirty = false;
@@ -195,19 +196,21 @@ describe('info builder', () => {
 
     props.subElement = ['row', '1'];
     const infoObject = buildAttributeInfo(props);
-    expect(infoObject.info.addRowAbove).toBeDefined();
-    expect(infoObject.info.addRowBelow).toBeDefined();
-    expect(infoObject.info.deleteRow).toBeDefined();
-    infoObject.info.addRowBelow.functions.clickHandler();
+    expect(infoObject.info.rowOperations.addRowAbove).toBeDefined();
+    expect(infoObject.info.rowOperations.addRowBelow).toBeDefined();
+    expect(infoObject.info.rowOperations.deleteRow).toBeDefined();
+    expect(infoObject.info.rowOperations.moveRowUp).toBeDefined();
+    expect(infoObject.info.rowOperations.moveRowDown).toBeDefined();
+    infoObject.info.rowOperations.addRowBelow.functions.clickHandler();
     expect(props.addRow).toHaveBeenCalledTimes(1);
     expect(props.addRow).toHaveBeenCalledWith(['test1', 'layout'], 1, 'below');
     props.addRow.mockClear();
-    infoObject.info.deleteRow.functions.clickHandler();
+    infoObject.info.rowOperations.deleteRow.functions.clickHandler();
     expect(props.addRow).toHaveBeenCalledTimes(1);
     expect(props.addRow).toHaveBeenCalledWith(['test1', 'layout'], 1, 'delete');
     expect(props.changeInfoHandler).toHaveBeenCalledTimes(0);
     props.addRow.mockClear();
-    infoObject.info.addRowAbove.functions.clickHandler();
+    infoObject.info.rowOperations.addRowAbove.functions.clickHandler();
     expect(props.addRow).toHaveBeenCalledTimes(1);
     expect(props.addRow).toHaveBeenCalledWith(['test1', 'layout'], 1);
     expect(props.changeInfoHandler).toHaveBeenCalledTimes(1);
@@ -215,6 +218,12 @@ describe('info builder', () => {
       ['test1', 'layout'],
       'row.2'
     );
+    infoObject.info.rowOperations.moveRowUp.functions.clickHandler();
+    expect(props.moveRow).toHaveBeenCalledTimes(1);
+
+    props.moveRow.mockClear();
+    infoObject.info.rowOperations.moveRowDown.functions.clickHandler();
+    expect(props.moveRow).toHaveBeenCalledTimes(1);
   });
 
   it('table delete row methods fires info route change if bottom row selected', () => {
@@ -231,7 +240,7 @@ describe('info builder', () => {
     const infoObject = buildAttributeInfo(props);
 
     props.addRow.mockClear();
-    infoObject.info.deleteRow.functions.clickHandler();
+    infoObject.info.rowOperations.deleteRow.functions.clickHandler();
     expect(props.addRow).toHaveBeenCalledTimes(1);
     expect(props.addRow).toHaveBeenCalledWith(['test1', 'layout'], 4, 'delete');
     expect(props.changeInfoHandler).toHaveBeenCalledTimes(1);
@@ -258,7 +267,7 @@ describe('info builder', () => {
     const infoObject = buildAttributeInfo(props);
 
     props.addRow.mockClear();
-    infoObject.info.deleteRow.functions.clickHandler();
+    infoObject.info.rowOperations.deleteRow.functions.clickHandler();
     expect(props.addRow).toHaveBeenCalledTimes(1);
     expect(props.addRow).toHaveBeenCalledWith(['test1', 'layout'], 0, 'delete');
     expect(props.closeInfoHandler).toHaveBeenCalledTimes(1);

--- a/src/infoDetails/infoDetails.component.js
+++ b/src/infoDetails/infoDetails.component.js
@@ -275,6 +275,9 @@ const mapDispatchToProps = dispatch => ({
   addRow: (path, row, modifier) => {
     dispatch(malcolmUpdateTable(path, { insertRow: true, modifier }, row));
   },
+  moveRow: (path, row, modifier) => {
+    dispatch(malcolmUpdateTable(path, { moveRow: true, modifier }, row));
+  },
   unselectLink: path => {
     dispatch(deselectLinkAction(path));
   },

--- a/src/infoDetails/infoDetails.component.js
+++ b/src/infoDetails/infoDetails.component.js
@@ -139,7 +139,14 @@ export class InfoDetails extends React.Component {
     );
     return (
       <div>
-        {infoElements.map(a => (
+        {[
+          ...infoElements.filter(
+            a => this.state.info[a] && this.state.info[a].tag !== 'info:button'
+          ),
+          ...infoElements.filter(
+            a => this.state.info[a] && this.state.info[a].tag === 'info:button'
+          ),
+        ].map(a => (
           <InfoElement
             key={a}
             label={this.state.info[a].label ? this.state.info[a].label : a}

--- a/src/malcolm/reducer/table.reducer.js
+++ b/src/malcolm/reducer/table.reducer.js
@@ -165,6 +165,23 @@ export const updateTableLocal = (state, payload) => {
       attribute.localState.flags.rows.slice(insertAt).forEach((row, index) => {
         attribute.localState.flags.rows[index + insertAt]._isChanged = true;
       });
+    } else if (payload.value.moveRow) {
+      const moveTo =
+        payload.value.modifier === 'below' ? payload.row + 1 : payload.row - 1;
+      const rowValue = deepCopy(attribute.localState.value[payload.row]);
+      const swapWith = deepCopy(attribute.localState.value[moveTo]);
+      const rowFlags = deepCopy(attribute.localState.flags.rows[payload.row]);
+      const swapWithFlags = deepCopy(attribute.localState.flags.rows[moveTo]);
+      attribute.localState.value[payload.row] = swapWith;
+      attribute.localState.value[moveTo] = rowValue;
+      attribute.localState.flags.rows[payload.row] = {
+        ...swapWithFlags,
+        _isChanged: true,
+      };
+      attribute.localState.flags.rows[moveTo] = {
+        ...rowFlags,
+        _isChanged: true,
+      };
     } else {
       attribute.localState.value[payload.row] = payload.value;
 

--- a/src/malcolm/reducer/table.reducer.test.js
+++ b/src/malcolm/reducer/table.reducer.test.js
@@ -245,6 +245,44 @@ describe('Table reducer', () => {
     );
   });
 
+  it('moves row up', () => {
+    const payload = {
+      path: ['block1', 'layout'],
+      value: { moveRow: true },
+      row: 1,
+    };
+    const action = {
+      type: MalcolmTableUpdate,
+      payload,
+    };
+    testState = TableReducer(testState, action);
+    expect(testState.blocks.block1.attributes[0].localState.value[0]).toEqual(
+      expectedCopy.value[1]
+    );
+    expect(testState.blocks.block1.attributes[0].localState.value[1]).toEqual(
+      expectedCopy.value[0]
+    );
+  });
+
+  it('moves row down', () => {
+    const payload = {
+      path: ['block1', 'layout'],
+      value: { moveRow: true, modifier: 'below' },
+      row: 1,
+    };
+    const action = {
+      type: MalcolmTableUpdate,
+      payload,
+    };
+    testState = TableReducer(testState, action);
+    expect(testState.blocks.block1.attributes[0].localState.value[1]).toEqual(
+      expectedCopy.value[2]
+    );
+    expect(testState.blocks.block1.attributes[0].localState.value[2]).toEqual(
+      expectedCopy.value[1]
+    );
+  });
+
   it('updates existing local state copy', () => {
     testState.blocks.block1.attributes[0].localState.value = expectedValue;
     testState = TableReducer(state, copyAction);

--- a/src/malcolmWidgets/table/__snapshots__/virtualizedTable.component.test.js.snap
+++ b/src/malcolmWidgets/table/__snapshots__/virtualizedTable.component.test.js.snap
@@ -881,10 +881,10 @@ exports[`virtualized table widget table renders correctly for array attribute wi
       <div
         style={
           Object {
-            "height": "100%",
+            "height": "calc(100% - 12px)",
             "overflowX": "auto",
             "overflowY": "hidden",
-            "width": "100%",
+            "paddingBottom": "12px",
           }
         }
       >
@@ -911,7 +911,7 @@ exports[`virtualized table widget table renders correctly for array attribute wi
                 headerHeight={36}
                 headerRowRenderer={[Function]}
                 headerStyle={Object {}}
-                height={0}
+                height={-12}
                 noRowsRenderer={[Function]}
                 onHeaderClick={[Function]}
                 onRowClick={[Function]}
@@ -1012,7 +1012,7 @@ exports[`virtualized table widget table renders correctly for array attribute wi
                     headerHeight={36}
                     headerRowRenderer={[Function]}
                     headerStyle={Object {}}
-                    height={-36}
+                    height={-48}
                     isScrollingOptOut={false}
                     noContentRenderer={[Function]}
                     noRowsRenderer={[Function]}
@@ -1057,7 +1057,7 @@ exports[`virtualized table widget table renders correctly for array attribute wi
                           "WebkitOverflowScrolling": "touch",
                           "boxSizing": "border-box",
                           "direction": "ltr",
-                          "height": -36,
+                          "height": -48,
                           "overflowX": "hidden",
                           "overflowY": "auto",
                           "position": "relative",
@@ -1408,10 +1408,10 @@ exports[`virtualized table widget table renders correctly for array attribute wi
       <div
         style={
           Object {
-            "height": "100%",
+            "height": "calc(100% - 12px)",
             "overflowX": "auto",
             "overflowY": "hidden",
-            "width": "100%",
+            "paddingBottom": "12px",
           }
         }
       >
@@ -1438,7 +1438,7 @@ exports[`virtualized table widget table renders correctly for array attribute wi
                 headerHeight={36}
                 headerRowRenderer={[Function]}
                 headerStyle={Object {}}
-                height={0}
+                height={-12}
                 noRowsRenderer={[Function]}
                 onHeaderClick={[Function]}
                 onRowClick={[Function]}
@@ -1539,7 +1539,7 @@ exports[`virtualized table widget table renders correctly for array attribute wi
                     headerHeight={36}
                     headerRowRenderer={[Function]}
                     headerStyle={Object {}}
-                    height={-36}
+                    height={-48}
                     isScrollingOptOut={false}
                     noContentRenderer={[Function]}
                     noRowsRenderer={[Function]}
@@ -1584,7 +1584,7 @@ exports[`virtualized table widget table renders correctly for array attribute wi
                           "WebkitOverflowScrolling": "touch",
                           "boxSizing": "border-box",
                           "direction": "ltr",
-                          "height": -36,
+                          "height": -48,
                           "overflowX": "hidden",
                           "overflowY": "auto",
                           "position": "relative",
@@ -3255,10 +3255,10 @@ exports[`virtualized table widget table renders correctly with no selected row 1
       <div
         style={
           Object {
-            "height": "100%",
+            "height": "calc(100% - 12px)",
             "overflowX": "auto",
             "overflowY": "hidden",
-            "width": "100%",
+            "paddingBottom": "12px",
           }
         }
       >
@@ -3285,7 +3285,7 @@ exports[`virtualized table widget table renders correctly with no selected row 1
                 headerHeight={36}
                 headerRowRenderer={[Function]}
                 headerStyle={Object {}}
-                height={0}
+                height={-12}
                 noRowsRenderer={[Function]}
                 onHeaderClick={[Function]}
                 onRowClick={[Function]}
@@ -3773,7 +3773,7 @@ exports[`virtualized table widget table renders correctly with no selected row 1
                     headerHeight={36}
                     headerRowRenderer={[Function]}
                     headerStyle={Object {}}
-                    height={-36}
+                    height={-48}
                     isScrollingOptOut={false}
                     noContentRenderer={[Function]}
                     noRowsRenderer={[Function]}
@@ -3818,7 +3818,7 @@ exports[`virtualized table widget table renders correctly with no selected row 1
                           "WebkitOverflowScrolling": "touch",
                           "boxSizing": "border-box",
                           "direction": "ltr",
-                          "height": -36,
+                          "height": -48,
                           "overflowX": "hidden",
                           "overflowY": "auto",
                           "position": "relative",

--- a/src/malcolmWidgets/table/virtualizedTable.component.js
+++ b/src/malcolmWidgets/table/virtualizedTable.component.js
@@ -25,6 +25,7 @@ const styles = theme => ({
     fontFamily: 'Roboto',
     fontWeight: 'normal',
     color: theme.palette.text.primary,
+    paddingRight: '0px !important',
   },
   incompleteRowFormat: {
     backgroundColor: emphasize(theme.palette.background.paper, 0.5),
@@ -324,10 +325,10 @@ const WidgetTable = props => {
     >
       <div
         style={{
-          width: '100%',
-          height: '100%',
+          height: 'calc(100% - 12px)',
           overflowX: 'auto',
           overflowY: 'hidden',
+          paddingBottom: '12px',
         }}
       >
         <AutoSizer>

--- a/src/middlePanelViews/attributeView/__snapshots__/archiveTable.container.test.js.snap
+++ b/src/middlePanelViews/attributeView/__snapshots__/archiveTable.container.test.js.snap
@@ -16,10 +16,10 @@ exports[`archiveTable renders correctly 1`] = `
   <div
     style={
       Object {
-        "height": "100%",
+        "height": "calc(100% - 12px)",
         "overflowX": "auto",
         "overflowY": "hidden",
-        "width": "100%",
+        "paddingBottom": "12px",
       }
     }
   >


### PR DESCRIPTION
## Description
- Fixed styling on tables so vertical scroll bar doesn't cause table to overflow div horizontally
- Added move row buttons and column info to table info pane.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- npm start
- navigate to localhost:3000/PANDA:SEQ1/table
- check that the table extends fully to the right of the screen even when it has a vertical scroll bar
- click the info icon on a row and try the move row buttons
- click a column heading and view the column info pane.

## Agile board tracking

connect to #398 
closes #398 
connect to #242 
closes #242 
connect to #259 
closes #259