### PR TITLE
Fixed bug in processing unpacked method returns

### DIFF
--- a/src/malcolm/actions/layout.action.js
+++ b/src/malcolm/actions/layout.action.js
@@ -10,6 +10,7 @@ import {
   malcolmPutAction,
   malcolmSetFlag,
   malcolmSelectBlock,
+  malcolmSelectLink,
 } from '../malcolmActionCreators';
 import blockUtils from '../blockUtils';
 import { snackbarState } from '../../viewState/viewState.actions';
@@ -181,6 +182,7 @@ const deleteLinks = () => (dispatch, getState) => {
         .slice(-1)[0];
       dispatch(malcolmSetFlag([blockMri, linkAttr], 'pending', true));
       dispatch(malcolmPutAction([blockMri, linkAttr], portNullValue));
+      dispatch(malcolmSelectLink(linkId, false));
     }
   });
 };

--- a/src/malcolm/actions/layout.action.test.js
+++ b/src/malcolm/actions/layout.action.test.js
@@ -5,6 +5,7 @@ import {
   MalcolmSend,
   MalcolmMakeBlockVisibleType,
   MalcolmSelectBlock,
+  MalcolmSelectLinkType,
 } from '../malcolm.types';
 import { idSeparator } from '../../layout/layout.component';
 import { sinkPort, sourcePort } from '../malcolmConstants';
@@ -199,16 +200,18 @@ describe('layout actions', () => {
     const action = LayoutActions.deleteLinks();
     action(dispatch, getState);
 
-    expect(actions).toHaveLength(4);
+    expect(actions).toHaveLength(6);
     expect(actions[0].type).toEqual(MalcolmAttributeFlag);
-    expect(actions[2].type).toEqual(MalcolmAttributeFlag);
+    expect(actions[3].type).toEqual(MalcolmAttributeFlag);
     expect(actions[1].type).toEqual(MalcolmSend);
     expect(actions[1].payload.typeid).toEqual('malcolm:core/Put:1.0');
     expect(actions[1].payload.path).toEqual(['PANDA:INENC1', 'testIn2']);
     expect(actions[1].payload.value).toEqual('ZERO');
-    expect(actions[3].type).toEqual(MalcolmSend);
-    expect(actions[3].payload.typeid).toEqual('malcolm:core/Put:1.0');
-    expect(actions[3].payload.path).toEqual(['PANDA', 'testIn1']);
-    expect(actions[3].payload.value).toEqual('ONE');
+    expect(actions[4].type).toEqual(MalcolmSend);
+    expect(actions[4].payload.typeid).toEqual('malcolm:core/Put:1.0');
+    expect(actions[4].payload.path).toEqual(['PANDA', 'testIn1']);
+    expect(actions[4].payload.value).toEqual('ONE');
+    expect(actions[2].type).toEqual(MalcolmSelectLinkType);
+    expect(actions[5].type).toEqual(MalcolmSelectLinkType);
   });
 });

--- a/src/malcolm/malcolm.types.js
+++ b/src/malcolm/malcolm.types.js
@@ -35,3 +35,4 @@ export const MalcolmSimpleLocalState = 'malcolm:simplelocalstate';
 export const MalcolmIncrementMessageCount = 'malcolm:incrementcounter';
 export const MalcolmClearError = 'malcolm:clearerror';
 export const MalcolmZoom = 'malcolm:zoomlayout';
+export const MalcolmMethodReturn = 'malcolm:methodreturn';

--- a/src/malcolm/malcolmActionCreators.js
+++ b/src/malcolm/malcolmActionCreators.js
@@ -18,6 +18,7 @@ import {
   MalcolmSelectLinkType,
   MalcolmSimpleLocalState,
   MalcolmClearError,
+  MalcolmMethodReturn,
 } from './malcolm.types';
 import blockUtils from './blockUtils';
 import {
@@ -289,6 +290,11 @@ export const malcolmClearLayoutSelect = () => (dispatch, getState) => {
     dispatch(malcolmSelectBlock(block, false))
   );
 };
+
+export const malcolmProcessMethodReturn = payload => ({
+  type: MalcolmMethodReturn,
+  payload,
+});
 
 export default {
   malcolmHailReturn,

--- a/src/malcolm/malcolmHandlers/blockMetaHandler.js
+++ b/src/malcolm/malcolmHandlers/blockMetaHandler.js
@@ -7,6 +7,7 @@ import {
 import { subscriptionActive } from '../middleware/malcolmReduxMiddleware';
 
 export const rootBlockSubPath = ['.', 'blocks', 'value'];
+// export const rootBlockSubPath = ['.', 'blocks'];
 
 export const BlockMetaHandler = (
   request,

--- a/src/malcolm/malcolmSocketHandler.js
+++ b/src/malcolm/malcolmSocketHandler.js
@@ -9,6 +9,7 @@ import {
   malcolmSetDisconnected,
   malcolmSetFlag,
   malcolmHailReturn,
+  malcolmProcessMethodReturn,
 } from './malcolmActionCreators';
 import { snackbarState } from '../viewState/viewState.actions';
 import { MalcolmAttributeData } from './malcolm.types';
@@ -62,17 +63,29 @@ const handleMessages = (messages, dispatch, getState) => {
         break;
       }
       case 'malcolm:core/Return:1.0': {
-        if (data.value && data.value.typeid === 'malcolm:core/BlockMeta:1.0') {
-          BlockMetaHandler(
-            originalRequest,
-            data.value,
-            dispatch,
-            messagesInFlight,
-            false,
-            true
-          );
-        } else if (data.value && data.value.typeid.slice(0, 8) === 'epics:nt') {
-          AttributeHandler.processAttribute(originalRequest, data.value);
+        switch (messagesInFlight[data.id].typeid) {
+          case 'malcolm:core/Get:1.0':
+            if (data.value && data.value.typeid) {
+              // Handle return from a Get
+              if (data.value.typeid === 'malcolm:core/BlockMeta:1.0') {
+                BlockMetaHandler(
+                  originalRequest,
+                  data.value,
+                  dispatch,
+                  messagesInFlight,
+                  false,
+                  true
+                );
+              } else if (data.value.typeid.slice(0, 8) === 'epics:nt') {
+                AttributeHandler.processAttribute(originalRequest, data.value);
+              }
+            }
+            break;
+          case 'malcolm:core/Post:1.0':
+            dispatch(malcolmProcessMethodReturn(data));
+            break;
+          default:
+            break;
         }
         dispatch(malcolmHailReturn(data, false));
         dispatch(malcolmSetFlag(originalRequest.path, 'pending', false));

--- a/src/malcolm/reducer/method.reducer.js
+++ b/src/malcolm/reducer/method.reducer.js
@@ -3,7 +3,7 @@ import blockUtils from '../blockUtils';
 import { AlarmStates } from '../../malcolmWidgets/attributeDetails/attributeAlarm/attributeAlarm.component';
 import {
   MalcolmUpdateMethodInputType,
-  MalcolmReturn,
+  MalcolmMethodReturn,
   MalcolmArchiveMethodRun,
   MalcolmFlagMethodInputType,
 } from '../malcolm.types';
@@ -223,7 +223,7 @@ const MethodReducer = createReducer(
   {},
   {
     [MalcolmUpdateMethodInputType]: updateMethodInput,
-    [MalcolmReturn]: handleMethodReturn,
+    [MalcolmMethodReturn]: handleMethodReturn,
     [MalcolmArchiveMethodRun]: pushParamsToArchive,
     [MalcolmFlagMethodInputType]: setInputFlag,
   }

--- a/src/malcolm/reducer/method.reducer.test.js
+++ b/src/malcolm/reducer/method.reducer.test.js
@@ -3,6 +3,7 @@ import blockUtils from '../blockUtils';
 import {
   MalcolmUpdateMethodInputType,
   MalcolmReturn,
+  MalcolmMethodReturn,
   MalcolmArchiveMethodRun,
   MalcolmFlagMethodInputType,
 } from '../malcolm.types';
@@ -212,7 +213,7 @@ describe('method reducer', () => {
       value: { output1: 456 },
     };
 
-    const test = runReducer(MalcolmReturn, payload, 'state');
+    const test = runReducer(MalcolmMethodReturn, payload, 'state');
     const attribute =
       test.updatedState.blocks.block1.attributes[test.attribute];
     const archive =
@@ -253,7 +254,7 @@ describe('method reducer', () => {
       value: 456,
     };
 
-    const test = runReducer(MalcolmReturn, payload, 'state');
+    const test = runReducer(MalcolmMethodReturn, payload, 'state');
     expect(
       test.updatedState.blocks.block1.attributes[test.attribute].calculated
         .outputs.output1
@@ -303,7 +304,7 @@ describe('method reducer', () => {
       value: { output1: 456 },
     };
 
-    const attribute = runReducer(MalcolmReturn, payload);
+    const attribute = runReducer(MalcolmMethodReturn, payload);
     expect(attribute.calculated.errorState).toBeTruthy();
   });
 });

--- a/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
+++ b/src/malcolmWidgets/attributeDetails/attributeDetails.component.js
@@ -61,7 +61,7 @@ const copyPathToClipboard = (event, path) => {
 const EMPTY_STRING = '';
 
 const AttributeDetails = props => {
-  if (props.widgetTagIndex !== null) {
+  if (![null, -1].includes(props.widgetTagIndex)) {
     const rowHighlight = props.isMainAttribute
       ? { backgroundColor: fade(props.theme.palette.secondary.main, 0.25) }
       : {};


### PR DESCRIPTION
## Description

SocketHandler now dispatches a new action for method returns with the same data, so only the socket reducer acts on the return action.
Also fixed bug where fields without widget tags were being displayed in attribute details.

## Testing instructions

Add a set up instructions describing how the reviewer should test the code
- Review code
- Check Travis build
- Review changes to test coverage
- run up the DEMO-HELLO.yaml (as per the pymalcolm tutorial)
- edit public/settings.json to connect to the pymalcolm instance & npm run ui-only
- navigate to localhost:3000/gui/HELLO
- try running the greet method and check that it returns the greeting successfully 

## Agile board tracking

connect to #444 
connect to #439 
connect to #441 
closes #444 
closes #439
closes #441 
